### PR TITLE
chore(release): crates.io metadata + README badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/AreevAI/flowcat"
+homepage = "https://areevai.github.io/flowcat/"
+keywords = ["voice", "telephony", "sip", "webrtc", "realtime"]
+categories = ["multimedia::audio", "network-programming"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Flowcat
 
+[![CI](https://github.com/AreevAI/flowcat/actions/workflows/ci.yml/badge.svg)](https://github.com/AreevAI/flowcat/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-areevai.github.io-blue)](https://areevai.github.io/flowcat/)
+
 **A native-Rust runtime for real-time voice agents — built to run on your own
 infrastructure.** Flowcat carries a phone or WebRTC call through a composable
 media pipeline — transport in → VAD / turn-taking → STT · LLM · TTS (or a single

--- a/flowcat-cli/Cargo.toml
+++ b/flowcat-cli/Cargo.toml
@@ -4,15 +4,19 @@ description = "Flowcat developer CLI — local-mic / WebSocket demo harness."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [[bin]]
 name = "flowcat"
 path = "src/main.rs"
 
 [dependencies]
-flowcat-core = { path = "../flowcat-core" }
+flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
 # The generic WebSocket media transport (`WsTransport`) used by the `ws-echo` demo.
-flowcat-transports = { path = "../flowcat-transports", features = ["ws"] }
+flowcat-transports = { path = "../flowcat-transports", version = "0.1.0", features = ["ws"] }
 # `#[async_trait]` for the demo `FrameProcessor`/`FrameObserver` impls (same
 # version flowcat-core/-transports use).
 async-trait = "0.1"

--- a/flowcat-core/Cargo.toml
+++ b/flowcat-core/Cargo.toml
@@ -4,6 +4,10 @@ description = "Self-hosted native-Rust real-time voice-agent runtime — one bin
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # Feature matrix. `sip`/`recorder` are additive
 # no-op flags made explicit (the SIP UA + recorder are always compiled today;

--- a/flowcat-services/Cargo.toml
+++ b/flowcat-services/Cargo.toml
@@ -4,6 +4,10 @@ description = "Flowcat speech/LLM service providers: realtime S2S (Gemini siblin
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # EVERY provider dep is declared
 # `optional` and reached only via a `dep:`-gated feature, so a default build
@@ -168,7 +172,7 @@ obs-all      = ["obs-otel", "obs-sentry", "obs-langfuse"]
 
 [dependencies]
 # Always on: the frozen service traits + Frame enum the impls build against.
-flowcat-core = { path = "../flowcat-core" }
+flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
 async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/flowcat-telephony/Cargo.toml
+++ b/flowcat-telephony/Cargo.toml
@@ -4,6 +4,10 @@ description = "Flowcat carrier WebSocket FrameSerializers (Twilio/Telnyx/Plivo/E
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # Each carrier serializer is behind its
 # own feature (no extra dep — they only need base64+serde_json, already on). The
@@ -24,7 +28,7 @@ vobiz = []
 dtmf-inband = []   # in-band Goertzel DTMF detection (RFC2833 is always available)
 
 [dependencies]
-flowcat-core = { path = "../flowcat-core" }
+flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/flowcat-transports/Cargo.toml
+++ b/flowcat-transports/Cargo.toml
@@ -4,6 +4,10 @@ description = "Flowcat media transports: str0m WebRTC + Opus, WebSocket, Daily/L
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # Every transport SDK is `optional` +
 # reached only via a `dep:`-gated feature, so a default build compiles nothing
@@ -25,7 +29,7 @@ livekit      = []
 local        = ["dep:audiopus", "dep:tokio"]
 
 [dependencies]
-flowcat-core = { path = "../flowcat-core" }
+flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
 async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## What
Release-prep so the crates are publishable to crates.io and the README shows status badges.

## Changes
- `[workspace.package]`: `repository`, `homepage` (docs site), `keywords`, `categories` — inherited by all five publishable crates.
- Internal path-deps now carry `version = "0.1.0"` (required by `cargo publish`; local builds still resolve via `path`).
- README: CI / license / docs badges.

## Verification
- `cargo build --workspace` ✓
- `cargo publish -p flowcat-core --dry-run` ✓ (metadata valid; 54 files packaged)
- Publish order when ready: `flowcat-core` → `services`/`transports`/`telephony` → `flowcat-cli`.
