### PR TITLE
feat(agent): add flowcat-agent — declarative graph-based AgentBrain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ file): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`PROCESSOR-DESIGN.md`](PROCESSOR-D
   MCP, one Cargo feature each.
 - `flowcat-transports/` — WebRTC (`str0m`) / WebSocket / Daily / LiveKit / local.
 - `flowcat-telephony/` — carrier serializers (Twilio/Telnyx/Plivo/…) + DTMF.
+- `flowcat-agent/` — declarative graph agent: a config-driven `AgentBrain`
+  (`DeclarativeBrain`) over a node/edge graph spec; default-on `brain` feature,
+  or pure engine with `default-features = false`.
 - `flowcat-cli/` — the `flowcat` demo binary.
 - `bench/`, `bench-rs/` — the reproducible pipecat-vs-flowcat benchmark kit.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +454,29 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -872,6 +904,18 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flowcat-agent"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "flowcat-core",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "flowcat-cli"
@@ -1435,6 +1479,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2056,6 +2124,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2748,6 +2834,12 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3629,6 +3721,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "flowcat-services",   # STT/TTS/LLM/realtime providers + obs exporters
     "flowcat-transports", # str0m WebRTC / WS / Daily / local / avatar
     "flowcat-telephony",  # carrier serializers + DTMF
+    "flowcat-agent",      # declarative graph agent (config-driven AgentBrain)
     "flowcat-cli",
 ]
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -128,6 +128,19 @@ Serializers are dependency-free flags (pure framing).
 | `twilio`, `telnyx`, `exotel`, `vonage`, `genesys`, `asterisk`, `cloudonix`, `vobiz` | — |
 | `dtmf-inband` | — (in-band Goertzel DTMF; RFC2833 is always available) |
 
+## `flowcat-agent` — `default = ["brain"]`
+
+A declarative, graph-based agent: define an agent as a node/edge `graph_spec`
+(JSON/YAML) instead of hand-writing an `AgentBrain`. `DeclarativeBrain` is a
+ready-to-use `flowcat_core::AgentBrain` over the graph engine.
+
+| Feature | Pulls |
+| --- | --- |
+| `brain` | `flowcat-core` — the `DeclarativeBrain` `AgentBrain` adapter (default on) |
+
+With `default-features = false` the pure graph engine (parse / validate /
+`{{var}}` interpolation) builds with no `flowcat-core` dependency.
+
 ---
 
 ## Toolchain caveats

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ flowcat/
 │                        #   — one cargo feature each
 ├── flowcat-transports/  # str0m WebRTC + Opus, WebSocket, Daily, LiveKit, local
 ├── flowcat-telephony/   # carrier FrameSerializers (Twilio/Telnyx/Plivo/…) + DTMF
+├── flowcat-agent/       # declarative graph agent — a config-driven AgentBrain
 ├── flowcat-cli/         # `flowcat` demo binary (DX / examples surface)
 ├── bench/               # the reproducible pipecat-vs-flowcat benchmark kit + RESULTS.md
 ├── bench-rs/            # standalone load-gen + framework micro-bench

--- a/flowcat-agent/Cargo.toml
+++ b/flowcat-agent/Cargo.toml
@@ -20,7 +20,7 @@ brain = ["dep:flowcat-core"]
 [dependencies]
 # Only the `brain` feature needs the runtime (for the `AgentBrain` seam +
 # `ToolDecl`/`BrainAction`); the engine + graph modules are pure logic.
-flowcat-core = { path = "../flowcat-core", optional = true }
+flowcat-core = { path = "../flowcat-core", version = "0.1.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/flowcat-agent/Cargo.toml
+++ b/flowcat-agent/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "flowcat-agent"
+description = "Declarative, graph-based conversation agent (a config-driven AgentBrain) for the Flowcat voice runtime."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[features]
+# The `AgentBrain` adapter (`DeclarativeBrain`) is on by default — running an
+# agent is the crate's purpose. Turn it off (`default-features = false`) to use
+# the pure graph engine (parse / validate / interpolate) without pulling in
+# `flowcat-core`.
+default = ["brain"]
+brain = ["dep:flowcat-core"]
+
+[dependencies]
+# Only the `brain` feature needs the runtime (for the `AgentBrain` seam +
+# `ToolDecl`/`BrainAction`); the engine + graph modules are pure logic.
+flowcat-core = { path = "../flowcat-core", optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+# Wall-clock time builtins in prompt interpolation (`{{current_time}}`,
+# `{{greeting_phrase}}`, …) — with IANA timezone support.
+chrono = "0.4"
+chrono-tz = "0.10"

--- a/flowcat-agent/src/brain.rs
+++ b/flowcat-agent/src/brain.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! [`DeclarativeBrain`] — a `flowcat_core::AgentBrain` backed by the graph [`Engine`].
+//!
+//! Drives one run's [`Engine`] directly through the `AgentBrain` seam: each graph
+//! transition is exposed as a no-arg tool the model can call to take that edge,
+//! plus an always-present `endCall` tool to hang up. This lets a config-driven
+//! host run a declarative agent without implementing `AgentBrain` by hand.
+
+use flowcat_core::{AgentBrain, BrainAction, ToolDecl};
+use serde_json::{json, Map, Value};
+
+use crate::engine::{Action, Engine, EngineError};
+
+/// The tool name the model calls to end the call. Distinct from the engine's
+/// transitions — `endCall` is offered on every node so the agent can always hang
+/// up, even from a node with no terminal edge.
+pub const END_CALL_TOOL: &str = "endCall";
+
+/// A flowcat-core brain that drives one run's declarative [`Engine`].
+///
+/// Construct it from the opaque `brain_config` a `SessionSource` returns
+/// ([`DeclarativeBrain::from_config`]) or directly from a graph spec
+/// ([`DeclarativeBrain::new`]).
+pub struct DeclarativeBrain {
+    engine: Engine,
+}
+
+impl DeclarativeBrain {
+    /// Build from a `brain_config` JSON object of the shape
+    /// `{ "graph_spec": {…}, "runtime_options": {…}, "seed_vars": {…} }` — the
+    /// opaque `ResolvedCall::brain_config` a `SessionSource` returns. Only
+    /// `graph_spec` is required; the others default to empty.
+    pub fn from_config(brain_config: &Value) -> Result<Self, EngineError> {
+        let graph_spec = brain_config
+            .get("graph_spec")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let runtime_options = brain_config
+            .get("runtime_options")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let seed_vars = brain_config
+            .get("seed_vars")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_else(Map::new);
+        Self::new(&graph_spec, runtime_options, seed_vars)
+    }
+
+    /// Build directly from a graph spec, runtime options and seed variables.
+    pub fn new(
+        graph_spec: &Value,
+        runtime_options: Value,
+        seed_vars: Map<String, Value>,
+    ) -> Result<Self, EngineError> {
+        Ok(Self {
+            engine: Engine::new(graph_spec, runtime_options, seed_vars)?,
+        })
+    }
+
+    /// The current node's tool set: one no-arg tool per transition, plus the
+    /// always-present `endCall` tool. Factored out so [`AgentBrain::tools`] and
+    /// the transition path build an identical set.
+    fn current_tools(&self) -> Vec<ToolDecl> {
+        let prompt = self.engine.current_prompt();
+        let mut tools: Vec<ToolDecl> = prompt
+            .transitions
+            .into_iter()
+            .map(|t| ToolDecl {
+                description: t
+                    .description
+                    .filter(|d| !d.trim().is_empty())
+                    .unwrap_or_else(|| format!("Take the '{}' transition.", t.name)),
+                name: t.name,
+                // Transitions are no-arg: the model only chooses *which* edge.
+                params: json!({ "type": "object", "properties": {} }),
+            })
+            .collect();
+        tools.push(end_call_tool());
+        tools
+    }
+}
+
+/// The `endCall` tool declaration: a single optional `disposition` string the
+/// model may set to label the outcome (folded into collected vars by the pipeline).
+fn end_call_tool() -> ToolDecl {
+    ToolDecl {
+        name: END_CALL_TOOL.to_string(),
+        description: "Hang up ONLY when the caller clearly asks to end (e.g. 'goodbye', \
+                      'that's all'). Do NOT end the call otherwise — keep talking. \
+                      Optional `disposition` label for the outcome (e.g. 'completed')."
+            .to_string(),
+        params: json!({
+            "type": "object",
+            "properties": {
+                "disposition": {
+                    "type": "string",
+                    "description": "Optional short outcome label for the call."
+                }
+            }
+        }),
+    }
+}
+
+impl AgentBrain for DeclarativeBrain {
+    fn system_prompt(&self) -> String {
+        self.engine.current_prompt().system_prompt
+    }
+
+    fn tools(&self) -> Vec<ToolDecl> {
+        self.current_tools()
+    }
+
+    fn current_node_id(&self) -> String {
+        // The pipeline scopes the node's MCP/HTTP tool lookup to this id.
+        self.engine.current_node().to_string()
+    }
+
+    fn on_tool_call(&mut self, name: &str, args: &Value) -> BrainAction {
+        // `endCall` is handled directly (it is not an engine edge): pull the
+        // optional disposition and end the call.
+        if name == END_CALL_TOOL {
+            let disposition = args
+                .get("disposition")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            return BrainAction::End { disposition };
+        }
+
+        // Otherwise it is an engine transition. The engine owns the decision; we
+        // translate its `Action` into the flowcat `BrainAction` the pipeline applies.
+        match self.engine.on_transition(name) {
+            Action::Transition { say, .. } => {
+                // The engine advanced — recompute the destination node's prompt +
+                // tool set so the model is re-armed for the new state.
+                let prompt = self.engine.current_prompt();
+                BrainAction::Transition {
+                    system_prompt: prompt.system_prompt,
+                    tools: self.current_tools(),
+                    say,
+                }
+            }
+            // Landing on a terminal node ends the call.
+            Action::End => BrainAction::End { disposition: None },
+            // Human escalation. flowcat-core has no transfer-capable `BrainAction`
+            // (it is the carrier-agnostic runtime), so an engine `Transfer` ends
+            // the session with a `transferred` disposition — the safe outcome (no
+            // stranded caller); a host that supports dial-out can special-case it.
+            Action::Transfer { .. } => BrainAction::End {
+                disposition: Some("transferred".to_string()),
+            },
+            // An unknown transition name keeps the current node.
+            Action::Stay => BrainAction::Stay,
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        self.engine.is_finished()
+    }
+
+    fn collected_vars(&self) -> Value {
+        // `snapshot()` → `{current, vars, runtime_options}`; take the harvested
+        // variables and fold in `nodes_visited` (the ordered list of nodes this
+        // run traversed) for observability.
+        let mut map = match self.engine.snapshot().get("vars").cloned() {
+            Some(Value::Object(m)) => m,
+            _ => serde_json::Map::new(),
+        };
+        map.insert(
+            "nodes_visited".to_string(),
+            Value::from(self.engine.visited_nodes().to_vec()),
+        );
+        Value::Object(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A two-node graph: start (with a prompt + one labelled edge) → end.
+    fn two_node_graph() -> Value {
+        json!({
+            "graph_spec": {
+                "nodes": [
+                    {"id": "s", "type": "startCall", "data": {
+                        "prompt": "Hi {{name}}, how can I help?"
+                    }},
+                    {"id": "done", "type": "endCall", "data": {"prompt": "Bye."}}
+                ],
+                "edges": [
+                    {"id": "e", "source": "s", "target": "done", "label": "Wrap up",
+                     "data": {"condition": "The caller is done"}}
+                ]
+            },
+            "runtime_options": {},
+            "seed_vars": {"name": "Sam"}
+        })
+    }
+
+    #[test]
+    fn new_seeds_vars_and_renders_prompt() {
+        let brain = DeclarativeBrain::from_config(&two_node_graph()).expect("engine builds");
+        assert_eq!(brain.system_prompt(), "Hi Sam, how can I help?");
+        assert!(!brain.is_finished());
+    }
+
+    #[test]
+    fn tools_are_transitions_plus_end_call() {
+        let brain = DeclarativeBrain::from_config(&two_node_graph()).expect("engine builds");
+        let tools = brain.tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        // The slugified edge label + the always-present endCall.
+        assert!(
+            names.contains(&"wrap_up"),
+            "transition tool present: {names:?}"
+        );
+        assert!(names.contains(&END_CALL_TOOL), "endCall present: {names:?}");
+        assert_eq!(tools.len(), 2, "exactly the transition + endCall");
+
+        // Each transition tool is a no-arg object schema.
+        let wrap = tools.iter().find(|t| t.name == "wrap_up").unwrap();
+        assert_eq!(wrap.params, json!({ "type": "object", "properties": {} }));
+        // Its description comes from the edge condition.
+        assert_eq!(wrap.description, "The caller is done");
+
+        // The endCall tool exposes an optional string `disposition` property.
+        let end = tools.iter().find(|t| t.name == END_CALL_TOOL).unwrap();
+        assert_eq!(end.params["type"], "object");
+        assert_eq!(end.params["properties"]["disposition"]["type"], "string");
+    }
+
+    #[test]
+    fn end_call_maps_to_end_with_disposition() {
+        let mut brain = DeclarativeBrain::from_config(&two_node_graph()).expect("engine builds");
+        match brain.on_tool_call(END_CALL_TOOL, &json!({ "disposition": "completed" })) {
+            BrainAction::End { disposition } => {
+                assert_eq!(disposition.as_deref(), Some("completed"))
+            }
+            other => panic!("expected End, got {other:?}"),
+        }
+        // endCall with no args → End with no disposition.
+        match brain.on_tool_call(END_CALL_TOOL, &json!({})) {
+            BrainAction::End { disposition } => assert!(disposition.is_none()),
+            other => panic!("expected End, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transition_to_terminal_node_ends_the_call() {
+        // The only edge lands on an `endCall` node, so taking it is terminal →
+        // the engine returns `End`, which the brain maps to `BrainAction::End`.
+        let mut brain = DeclarativeBrain::from_config(&two_node_graph()).expect("engine builds");
+        match brain.on_tool_call("wrap_up", &json!({})) {
+            BrainAction::End { disposition } => assert!(disposition.is_none()),
+            other => panic!("expected End on terminal transition, got {other:?}"),
+        }
+        assert!(brain.is_finished());
+    }
+
+    #[test]
+    fn transition_to_non_terminal_node_re_arms_prompt_and_tools() {
+        // start → middle (non-terminal, its own prompt + edge) → end.
+        let cfg = json!({
+            "graph_spec": {
+                "nodes": [
+                    {"id": "s", "type": "startCall", "data": {"prompt": "Start."}},
+                    {"id": "mid", "type": "agentNode", "data": {"prompt": "Now collecting details."}},
+                    {"id": "done", "type": "endCall", "data": {}}
+                ],
+                "edges": [
+                    {"id": "e1", "source": "s", "target": "mid", "label": "Proceed"},
+                    {"id": "e2", "source": "mid", "target": "done", "label": "Finish"}
+                ]
+            }
+        });
+        let mut brain = DeclarativeBrain::from_config(&cfg).expect("engine builds");
+        match brain.on_tool_call("proceed", &json!({})) {
+            BrainAction::Transition {
+                system_prompt,
+                tools,
+                ..
+            } => {
+                assert_eq!(system_prompt, "Now collecting details.");
+                let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+                // The destination node's edge (`finish`) + endCall.
+                assert!(
+                    names.contains(&"finish"),
+                    "re-armed with new tools: {names:?}"
+                );
+                assert!(names.contains(&END_CALL_TOOL));
+            }
+            other => panic!("expected Transition, got {other:?}"),
+        }
+        assert!(!brain.is_finished());
+    }
+
+    #[test]
+    fn unknown_tool_name_stays() {
+        let mut brain = DeclarativeBrain::from_config(&two_node_graph()).expect("engine builds");
+        assert!(matches!(
+            brain.on_tool_call("does_not_exist", &json!({})),
+            BrainAction::Stay
+        ));
+    }
+
+    #[test]
+    fn collected_vars_returns_seed_vars_object_with_nodes_visited() {
+        let brain = DeclarativeBrain::from_config(&two_node_graph()).expect("engine builds");
+        let vars = brain.collected_vars();
+        assert_eq!(vars["name"], "Sam");
+        // nodes_visited is folded in (at least the active node on construction).
+        assert!(
+            vars["nodes_visited"].is_array(),
+            "nodes_visited folded in: {vars}"
+        );
+        assert!(
+            !vars["nodes_visited"].as_array().unwrap().is_empty(),
+            "active node recorded: {vars}"
+        );
+    }
+
+    #[test]
+    fn current_node_id_tracks_the_engine_state() {
+        // start → middle → end; the brain's current_node_id follows the engine.
+        let cfg = json!({
+            "graph_spec": {
+                "nodes": [
+                    {"id": "s", "type": "startCall", "data": {"prompt": "Start."}},
+                    {"id": "mid", "type": "agentNode", "data": {"prompt": "Mid."}},
+                    {"id": "done", "type": "endCall", "data": {}}
+                ],
+                "edges": [
+                    {"id": "e1", "source": "s", "target": "mid", "label": "Proceed"},
+                    {"id": "e2", "source": "mid", "target": "done", "label": "Finish"}
+                ]
+            }
+        });
+        let mut brain = DeclarativeBrain::from_config(&cfg).expect("engine builds");
+        assert_eq!(brain.current_node_id(), "s");
+        // Take the first edge → the brain now reports the destination node.
+        let _ = brain.on_tool_call("proceed", &json!({}));
+        assert_eq!(brain.current_node_id(), "mid");
+    }
+
+    #[test]
+    fn end_call_tool_description_discourages_premature_hangup() {
+        // Guards against a permissive description that lets the model hang up
+        // mid-conversation (e.g. right after a transition).
+        let desc = end_call_tool().description.to_lowercase();
+        assert!(
+            desc.contains("only"),
+            "must restrict when endCall is allowed: {desc}"
+        );
+        assert!(
+            desc.contains("do not end the call"),
+            "must explicitly tell the model NOT to end prematurely: {desc}"
+        );
+    }
+}

--- a/flowcat-agent/src/engine.rs
+++ b/flowcat-agent/src/engine.rs
@@ -1,0 +1,1419 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! The graph decision engine. Pure logic: given a parsed graph and the run's
+//! variables, it tracks the active node, composes the per-node system prompt and
+//! the set of callable transitions, interpolates `{{variables}}`, and advances on
+//! a transition/tool call. No dependency on the media runtime — a host wraps it
+//! behind a `flowcat_core::AgentBrain` (the `DeclarativeBrain` adapter does this).
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+use crate::graph::{Graph, GraphError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    #[error(transparent)]
+    Graph(#[from] GraphError),
+    #[error("unknown node: {0}")]
+    UnknownNode(String),
+}
+
+/// How a human transfer is performed (cold / warm). **Operator-pinned** (node
+/// config), never LLM-chosen — same closed trust model as `target_phone`. `cold`
+/// ends the agent then bridges; `warm` keeps the agent streaming, dials +
+/// introduces the human, then bridges (honored only where the host supports it;
+/// falls back to cold otherwise).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferMode {
+    #[default]
+    Cold,
+    Warm,
+}
+
+/// What the host should do after a tool/transition call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Action {
+    /// Move to a node; the host should re-prompt the LLM with the new context.
+    Transition {
+        to_node: String,
+        /// Optional speech to play during the transition (text or recording id).
+        say: Option<String>,
+    },
+    /// Stay on the current node (e.g. an informational tool result).
+    Stay,
+    /// End the call/session.
+    End,
+    /// Escalate to a human. The host records a pending transfer for the run and
+    /// closes the media WS so the cold-transfer fallthrough dials `target_phone`.
+    /// `target_phone` is **operator-pinned** (read from node config) — never
+    /// LLM-chosen — so the set of reachable numbers is a closed list.
+    Transfer {
+        target_phone: String,
+        target_name: Option<String>,
+        /// Optional pre-transfer line spoken before the WS closes.
+        say: Option<String>,
+        /// cold (default) or warm (honored only where the host supports it).
+        #[serde(default)]
+        mode: TransferMode,
+    },
+}
+
+/// The prompt + transitions the host needs to configure the LLM for a turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodePrompt {
+    pub node_id: String,
+    pub system_prompt: String,
+    /// Tool/transition names the LLM may call from this node.
+    pub transitions: Vec<TransitionSpec>,
+    /// Operator-configured human-transfer targets exposed on this node (0 or more).
+    /// Each becomes a no-arg LLM function the host registers; the engine never lets
+    /// the LLM pick the number — `target_phone` comes straight from node config.
+    #[serde(default)]
+    pub transfer_targets: Vec<TransferTarget>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransitionSpec {
+    /// Stable name the LLM calls to take this edge.
+    pub name: String,
+    pub target: String,
+    pub description: Option<String>,
+}
+
+/// One operator-pinned human-escalation destination attached to a node. The
+/// LLM-facing function is no-arg: the model decides *whether* to escalate, never
+/// *to where* — the dialed number is fixed by node config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferTarget {
+    /// Stable function name the LLM calls (slugified tool name; default `transfer_call`).
+    pub name: String,
+    /// Operator-pinned E.164 destination. Never `var_interpolate`d — it must be a
+    /// literal the conversation can't rewrite.
+    pub target_phone: String,
+    #[serde(default)]
+    pub target_name: Option<String>,
+    /// LLM-facing "when to transfer" description (the tool's description field).
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Optional pre-transfer spoken line. Audio-recording variant deferred.
+    #[serde(default)]
+    pub say: Option<String>,
+    /// Escalation style: cold (default) or warm. Operator-pinned (not LLM-chosen);
+    /// warm is honored only where the host supports it (otherwise cold).
+    #[serde(default)]
+    pub mode: TransferMode,
+}
+
+/// Declared type of an extracted variable. Drives coercion of the LLM's JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum VarType {
+    #[default]
+    String,
+    Number,
+    Boolean,
+}
+
+/// One variable a node wants harvested from the conversation. Mirrors the
+/// node-spec `extraction_variables[]` entry (`name` / `type` / `prompt`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractionVar {
+    pub name: String,
+    #[serde(rename = "type", default)]
+    pub var_type: VarType,
+    /// Per-variable hint (node-spec field `prompt`).
+    #[serde(default, rename = "prompt")]
+    pub hint: Option<String>,
+}
+
+/// A node's variable-extraction configuration, when enabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractionSpec {
+    /// Overall extraction instruction (`extraction_prompt`).
+    #[serde(default)]
+    pub prompt: Option<String>,
+    pub variables: Vec<ExtractionVar>,
+}
+
+/// The active node's identity for a live-transcript node-transition marker.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeInfo {
+    pub id: String,
+    pub name: String,
+    pub allow_interrupt: Option<bool>,
+}
+
+/// Stateful engine for one run.
+pub struct Engine {
+    graph: Graph,
+    current: String,
+    pub vars: Map<String, Value>,
+    runtime_options: Value,
+    /// Ordered, first-visit-deduped display names of the nodes this run has been
+    /// active on — surfaced as `collected_vars.nodes_visited` for observability.
+    visited: Vec<String>,
+}
+
+impl Engine {
+    /// Build from the persisted graph spec, runtime options and seed variables.
+    pub fn new(
+        graph_spec: &Value,
+        runtime_options: Value,
+        seed_vars: Map<String, Value>,
+    ) -> Result<Self, EngineError> {
+        let graph = Graph::parse(graph_spec)?;
+        let current = graph.start_id.clone();
+        let mut engine = Self {
+            graph,
+            current,
+            vars: seed_vars,
+            runtime_options,
+            visited: Vec::new(),
+        };
+        // Auto-advance off the start node to the first real node if there is a
+        // single unconditional edge (start nodes carry no prompt of their own).
+        engine.advance_through_start();
+        engine.record_visit();
+        Ok(engine)
+    }
+
+    /// Skip a start node ONLY when it carries no opening prompt — i.e. the
+    /// synthetic `{type:"start"}` anchor used in hand-written graphs/tests.
+    /// Editor-authored `startCall` nodes carry a `data.prompt` (the agent's
+    /// opening utterance) and must be preserved as the active node so the first
+    /// turn delivers that prompt. Both kinds collapse to `NodeKind::Start` via
+    /// `#[serde(alias="startCall")]`, so we disambiguate by content, not by name.
+    fn advance_through_start(&mut self) {
+        let Some(node) = self.graph.node(&self.current) else {
+            return;
+        };
+        if !matches!(node.kind, crate::graph::NodeKind::Start) {
+            return;
+        }
+        let has_prompt = node
+            .data
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        if has_prompt {
+            return;
+        }
+        if let Some(edge) = self.graph.outgoing(&self.current).first() {
+            self.current = edge.target.clone();
+        }
+    }
+
+    /// Re-seat the engine at a previously persisted node id (resume after a
+    /// snapshot / restart). Returns `UnknownNode` if the id is not in the parsed
+    /// graph.
+    pub fn set_current_node(&mut self, node_id: &str) -> Result<(), EngineError> {
+        if self.graph.node(node_id).is_some() {
+            self.current = node_id.to_string();
+            self.record_visit();
+            Ok(())
+        } else {
+            Err(EngineError::UnknownNode(node_id.to_string()))
+        }
+    }
+
+    pub fn current_node(&self) -> &str {
+        &self.current
+    }
+
+    /// The active node's id, display name, and `allow_interrupt` flag — for a
+    /// node-transition transcript marker. `allow_interrupt` is read from the node's
+    /// `data` (`allow_interrupt`, or the `allowInterrupt` alias); `None` when the
+    /// field is absent.
+    pub fn current_node_info(&self) -> NodeInfo {
+        let allow_interrupt = self.graph.node(&self.current).and_then(|n| {
+            n.data
+                .get("allow_interrupt")
+                .or_else(|| n.data.get("allowInterrupt"))
+                .and_then(|v| v.as_bool())
+        });
+        NodeInfo {
+            id: self.current.clone(),
+            name: self.graph.node_name(&self.current),
+            allow_interrupt,
+        }
+    }
+
+    /// The ordered, deduped display names of nodes this run has visited.
+    pub fn visited_nodes(&self) -> &[String] {
+        &self.visited
+    }
+
+    /// Record the active node in `visited` (first-visit order, no duplicates).
+    fn record_visit(&mut self) {
+        let name = self.graph.node_name(&self.current);
+        if !self.visited.iter().any(|n| n == &name) {
+            self.visited.push(name);
+        }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.graph.is_terminal(&self.current)
+    }
+
+    /// Compose the prompt and the set of callable transitions for the active node.
+    pub fn current_prompt(&self) -> NodePrompt {
+        let node = self.graph.node(&self.current);
+        let raw_prompt = node
+            .and_then(|n| n.data.get("prompt"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let mut system_prompt = var_interpolate(&raw_prompt, &self.vars);
+
+        // Prepend the global directive (persona/tone) when this node opts in.
+        // The editor writes `add_global_prompt` per node (alias
+        // `inherit_global_directive`); default is to inherit when a global node
+        // exists.
+        let inherit_global = node
+            .and_then(|n| {
+                n.data
+                    .get("add_global_prompt")
+                    .or_else(|| n.data.get("inherit_global_directive"))
+            })
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        if inherit_global {
+            if let Some(global_raw) = self.graph.global_prompt() {
+                let global = var_interpolate(global_raw, &self.vars);
+                if !global.trim().is_empty() {
+                    system_prompt = if system_prompt.trim().is_empty() {
+                        global
+                    } else {
+                        format!("{global}\n\n{system_prompt}")
+                    };
+                }
+            }
+        }
+
+        let transitions = self
+            .graph
+            .outgoing(&self.current)
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| {
+                // The description the LLM reads to choose this edge is the edge's
+                // transition criteria (field `condition`; alias
+                // `transition_criteria`), falling back to the label.
+                let description = e
+                    .data
+                    .get("transition_criteria")
+                    .or_else(|| e.data.get("condition"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .filter(|s| !s.trim().is_empty())
+                    .or_else(|| e.label.clone());
+                TransitionSpec {
+                    name: e
+                        .label
+                        .clone()
+                        .map(|l| slugify(&l))
+                        .unwrap_or_else(|| format!("transition_{i}")),
+                    target: e.target.clone(),
+                    description,
+                }
+            })
+            .collect();
+
+        // Operator-pinned human-transfer destinations. Read
+        // from the node's `data.transfer_targets` array; `target_phone` is taken
+        // LITERAL (never interpolated — the conversation must not be able to
+        // rewrite the dialed number), while `say`/`description` get the same
+        // var-interpolation as prompts. Entries without a target_phone are dropped.
+        let transfer_targets: Vec<TransferTarget> = node
+            .and_then(|n| n.data.get("transfer_targets"))
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .enumerate()
+                    .filter_map(|(i, t)| {
+                        let target_phone = t
+                            .get("target_phone")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())?
+                            .to_string();
+                        let name = t
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .map(slugify)
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or_else(|| {
+                                if i == 0 {
+                                    "transfer_call".to_string()
+                                } else {
+                                    format!("transfer_call_{i}")
+                                }
+                            });
+                        let target_name = t
+                            .get("target_name")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                            .filter(|s| !s.trim().is_empty());
+                        let description = t
+                            .get("description")
+                            .and_then(Value::as_str)
+                            .filter(|s| !s.trim().is_empty())
+                            .map(|s| var_interpolate(s, &self.vars));
+                        let say = t
+                            .get("say")
+                            .and_then(Value::as_str)
+                            .filter(|s| !s.trim().is_empty())
+                            .map(|s| var_interpolate(s, &self.vars));
+                        // Operator-pinned escalation style (not interpolated). Only
+                        // "warm" opts into warm transfer; anything else is cold.
+                        let mode = match t.get("mode").and_then(Value::as_str) {
+                            Some("warm") => TransferMode::Warm,
+                            _ => TransferMode::Cold,
+                        };
+                        Some(TransferTarget {
+                            name,
+                            target_phone,
+                            target_name,
+                            description,
+                            say,
+                            mode,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // When this node exposes human-transfer targets, make the capability
+        // explicit in the system prompt. A realtime LLM will otherwise sometimes
+        // narrate "I can't transfer you" rather than call the (registered) no-arg
+        // function. The function still owns the pinned number; this only tells the
+        // model the capability exists and when to use it.
+        if !transfer_targets.is_empty() {
+            let names = transfer_targets
+                .iter()
+                .map(|t| t.name.as_str())
+                .collect::<Vec<_>>()
+                .join("` or `");
+            system_prompt.push_str(&format!(
+                "\n\n[Human escalation] If the caller asks to speak to a human, a person, \
+                 an agent, a manager, or to be transferred: FIRST say one short sentence \
+                 telling them you're connecting them to a human now and to please hold, \
+                 THEN call the `{names}` function. Never claim you are unable to transfer."
+            ));
+        }
+
+        NodePrompt {
+            node_id: self.current.clone(),
+            system_prompt,
+            transitions,
+            transfer_targets,
+        }
+    }
+
+    /// Apply a transition the LLM requested by name. Unknown names keep the
+    /// engine on the current node (`Stay`).
+    pub fn on_transition(&mut self, name: &str) -> Action {
+        let target = {
+            let specs = self.current_prompt().transitions;
+            specs.into_iter().find(|t| t.name == name).map(|t| t.target)
+        };
+        match target {
+            Some(to) => {
+                self.current = to.clone();
+                self.record_visit();
+                if self.is_finished() {
+                    Action::End
+                } else {
+                    Action::Transition {
+                        to_node: to,
+                        say: None,
+                    }
+                }
+            }
+            None => Action::Stay,
+        }
+    }
+
+    /// Apply a human-transfer the LLM requested by name. Looks
+    /// the name up in the active node's operator-configured `transfer_targets` and
+    /// returns `Action::Transfer` with the **pinned** number; an unknown name keeps
+    /// the engine on the current node (`Stay`). Unlike `on_transition`, this does
+    /// NOT advance the active node — the call ends via the media path (the host
+    /// records the pending transfer + closes the WS), like `endCall`.
+    pub fn on_transfer(&self, name: &str) -> Action {
+        match self
+            .current_prompt()
+            .transfer_targets
+            .into_iter()
+            .find(|t| t.name == name)
+        {
+            Some(t) => Action::Transfer {
+                target_phone: t.target_phone,
+                target_name: t.target_name,
+                say: t.say,
+                mode: t.mode,
+            },
+            None => Action::Stay,
+        }
+    }
+
+    /// The active node's variable-extraction config, if extraction is enabled
+    /// and at least one variable is declared. Pure — the host runs the actual
+    /// LLM extraction pass and feeds results back via [`Engine::capture`].
+    pub fn extraction_spec(&self) -> Option<ExtractionSpec> {
+        let node = self.graph.node(&self.current)?;
+        let enabled = node
+            .data
+            .get("extraction_enabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !enabled {
+            return None;
+        }
+        let variables: Vec<ExtractionVar> = node
+            .data
+            .get("extraction_variables")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|e| serde_json::from_value(e.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if variables.is_empty() {
+            return None;
+        }
+        let prompt = node
+            .data
+            .get("extraction_prompt")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty());
+        Some(ExtractionSpec { prompt, variables })
+    }
+
+    /// The tool ids (`tool_uuids`) the active node enables. The host loads the
+    /// tool definitions (from the store) and offers them to the LLM; pure here.
+    pub fn tool_refs(&self) -> Vec<String> {
+        self.string_array_field("tool_uuids")
+    }
+
+    /// The knowledge-base document ids (`document_uuids`) the active node attaches.
+    /// The host offers a retrieval tool scoped to these documents; pure here.
+    pub fn document_refs(&self) -> Vec<String> {
+        self.string_array_field("document_uuids")
+    }
+
+    /// Read a string-array field from the current node's `data` (empty if absent).
+    fn string_array_field(&self, key: &str) -> Vec<String> {
+        self.graph
+            .node(&self.current)
+            .and_then(|n| n.data.get(key))
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Merge extracted variables into the run context.
+    pub fn capture(&mut self, vars: Map<String, Value>) {
+        for (k, v) in vars {
+            self.vars.insert(k, v);
+        }
+    }
+
+    /// Serialize enough state to resume later (rewind / recovery).
+    pub fn snapshot(&self) -> Value {
+        serde_json::json!({
+            "current": self.current,
+            "vars": self.vars,
+            "runtime_options": self.runtime_options,
+        })
+    }
+}
+
+/// Interpolate `{{ path | fallback }}` placeholders in a string against the run
+/// variables. Supports:
+/// - **nested dot-paths** — `{{customer.contact.email}}` (object keys; numeric
+///   segments index arrays);
+/// - **fallbacks** — `{{name | there}}` and the legacy `{{name | fallback:there}}`;
+///   used when the path is missing, null, or an empty string;
+/// - **JSON values** — object/array values are serialised as JSON, scalars as
+///   their plain string;
+/// - literal `\n` → newline.
+///
+/// A missing path with no fallback renders empty. An unterminated `{{` is left
+/// literal. Also resolves **time builtins** against the wall clock:
+/// `{{current_time}}` / `{{current_date}}` / `{{current_weekday}}` (UTC) and a
+/// `_<IANA TZ>` suffix — `{{current_time_America/New_York}}` — for a local time.
+/// `{{greeting_phrase}}` renders an hour-bucketed time-of-day phrase ("Good
+/// morning" / "Good afternoon" / "Good evening" / "Hello"); it defaults to
+/// Asia/Singapore when bare and honours the same `_<IANA TZ>` suffix.
+pub fn var_interpolate(template: &str, vars: &Map<String, Value>) -> String {
+    var_interpolate_at(template, vars, chrono::Utc::now())
+}
+
+/// Pure core of [`var_interpolate`]: interpolates against an explicit `now`, so
+/// the time builtins are deterministically testable. The public wrapper supplies
+/// the wall clock — the only impurity lives there.
+fn var_interpolate_at(
+    template: &str,
+    vars: &Map<String, Value>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(open) = rest.find("{{") {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 2..];
+        match after.find("}}") {
+            Some(close) => {
+                let inner = &after[..close];
+                // Time builtins take precedence over a (non-existent) variable of
+                // the same name; everything else resolves against `vars`.
+                match time_builtin(inner.trim(), now) {
+                    Some(t) => out.push_str(&t),
+                    None => out.push_str(&resolve_placeholder(inner, vars)),
+                }
+                rest = &after[close + 2..];
+            }
+            None => {
+                // No closing braces — emit the literal `{{` and stop scanning.
+                out.push_str("{{");
+                rest = after;
+            }
+        }
+    }
+    out.push_str(rest);
+    out.replace("\\n", "\n")
+}
+
+/// Resolve a `current_time` / `current_date` / `current_weekday` /
+/// `greeting_phrase` placeholder (optionally `_<IANA TZ>`-suffixed) against `now`.
+/// Returns `None` for any other placeholder (so it falls through to variable
+/// resolution). An unrecognised/bad timezone yields `None` (renders empty rather
+/// than a wrong time).
+fn time_builtin(inner: &str, now: chrono::DateTime<chrono::Utc>) -> Option<String> {
+    use chrono::{Timelike, Utc};
+    // `greeting_phrase` → a time-of-day phrase, hour-bucketed. Unlike the `current_*`
+    // builtins (UTC when bare), the bare form defaults to Asia/Singapore — the
+    // primary market — since a time-of-day greeting only makes sense in a wall-clock
+    // local to the caller. A `_<IANA TZ>` suffix overrides that default.
+    if let Some(rest) = inner.strip_prefix("greeting_phrase") {
+        let hour = if rest.is_empty() {
+            now.with_timezone(&chrono_tz::Asia::Singapore).hour()
+        } else {
+            let tz: chrono_tz::Tz = rest.strip_prefix('_')?.parse().ok()?;
+            now.with_timezone(&tz).hour()
+        };
+        let phrase = match hour {
+            5..=11 => "Good morning",
+            12..=16 => "Good afternoon",
+            17..=21 => "Good evening",
+            _ => "Hello", // 22:00–04:59 — neutral; "good night" reads as a farewell.
+        };
+        return Some(phrase.to_string());
+    }
+    // (format, tz-suffix-or-empty). Order: longest distinct prefixes; the three
+    // kinds don't overlap.
+    let (fmt, tz_part) = if let Some(rest) = inner.strip_prefix("current_time") {
+        ("%Y-%m-%d %H:%M %Z", rest)
+    } else if let Some(rest) = inner.strip_prefix("current_weekday") {
+        ("%A", rest)
+    } else if let Some(rest) = inner.strip_prefix("current_date") {
+        ("%Y-%m-%d", rest)
+    } else {
+        return None;
+    };
+    if tz_part.is_empty() {
+        // UTC.
+        return Some(now.with_timezone(&Utc).format(fmt).to_string());
+    }
+    // `_<IANA name>`, e.g. `_America/New_York`. A leading `_` is required; a name
+    // we can't parse means "not a time builtin" → fall through (renders empty).
+    let tz_name = tz_part.strip_prefix('_')?;
+    let tz: chrono_tz::Tz = tz_name.parse().ok()?;
+    Some(now.with_timezone(&tz).format(fmt).to_string())
+}
+
+/// Recursively interpolate a JSON template: string leaves run through
+/// [`var_interpolate`]; object values and array items recurse (object keys are
+/// left as-is). Used for HTTP tool request bodies/params.
+pub fn var_interpolate_value(template: &Value, vars: &Map<String, Value>) -> Value {
+    match template {
+        Value::String(s) => Value::String(var_interpolate(s, vars)),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|i| var_interpolate_value(i, vars))
+                .collect(),
+        ),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), var_interpolate_value(v, vars)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// Resolve one `path | fallback` placeholder body.
+fn resolve_placeholder(inner: &str, vars: &Map<String, Value>) -> String {
+    let (path, fallback) = match inner.split_once('|') {
+        Some((p, f)) => {
+            let f = f.trim();
+            // Both `{{x | fallback:default}}` (legacy) and `{{x | default}}`.
+            let fb = f.strip_prefix("fallback:").map(str::trim).unwrap_or(f);
+            (p.trim(), Some(fb))
+        }
+        None => (inner.trim(), None),
+    };
+    match get_nested(vars, path) {
+        Some(v) if !is_empty_value(v) => value_to_string(v),
+        _ => fallback.unwrap_or("").to_string(),
+    }
+}
+
+/// Traverse a dot-path through objects (by key) and arrays (by index).
+fn get_nested<'a>(vars: &'a Map<String, Value>, path: &str) -> Option<&'a Value> {
+    let mut parts = path.split('.');
+    let mut cur = vars.get(parts.next()?)?;
+    for p in parts {
+        cur = match cur {
+            Value::Object(_) => cur.get(p)?,
+            Value::Array(arr) => arr.get(p.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(cur)
+}
+
+/// A null or empty-string value triggers the fallback.
+fn is_empty_value(v: &Value) -> bool {
+    matches!(v, Value::Null) || matches!(v, Value::String(s) if s.is_empty())
+}
+
+/// Render a resolved value: strings verbatim, objects/arrays as JSON, scalars
+/// as their plain representation, null as empty.
+fn value_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => String::new(),
+        Value::Object(_) | Value::Array(_) => v.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn slugify(label: &str) -> String {
+    label
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Validate a graph spec without instantiating a full run (structural parse
+/// only: start node present, no dangling edges).
+pub fn validate(graph_spec: &Value) -> Result<(), EngineError> {
+    Graph::parse(graph_spec)?;
+    Ok(())
+}
+
+/// Full validation for an editor's validate endpoint: structural parse
+/// (start node present, no dangling edges) PLUS per-node edge-cardinality rules.
+/// Returns structured [`crate::graph::ValidationError`]s (empty ⇒ valid) so the
+/// editor can highlight offending nodes; a structural parse failure becomes a
+/// single graph-level error. Unlike [`validate`]/`Graph::parse` this is not used
+/// to gate running a graph.
+pub fn validate_detailed(graph_spec: &Value) -> Vec<crate::graph::ValidationError> {
+    match Graph::parse(graph_spec) {
+        Ok(graph) => graph.cardinality_errors(),
+        Err(e) => vec![crate::graph::ValidationError {
+            kind: "graph",
+            id: None,
+            message: e.to_string(),
+        }],
+    }
+}
+
+// Reserved for richer extraction config keyed by node id.
+pub type ExtractionRules = HashMap<String, Value>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample() -> Value {
+        json!({
+            "nodes": [
+                {"id": "s", "type": "start"},
+                {"id": "greet", "type": "agent", "data": {"prompt": "Hello {{name}}"}},
+                {"id": "done", "type": "end"}
+            ],
+            "edges": [
+                {"id": "e1", "source": "s", "target": "greet"},
+                {"id": "e2", "source": "greet", "target": "done", "label": "Finish"}
+            ]
+        })
+    }
+
+    #[test]
+    fn starts_on_first_real_node_with_rendered_prompt() {
+        let mut seed = Map::new();
+        seed.insert("name".into(), json!("Sam"));
+        let eng = Engine::new(&sample(), json!({}), seed).unwrap();
+        assert_eq!(eng.current_node(), "greet");
+        assert_eq!(eng.current_prompt().system_prompt, "Hello Sam");
+    }
+
+    #[test]
+    fn visited_nodes_accumulate_in_first_visit_order_deduped() {
+        // start (no prompt → skipped) → greet ("Greeting") → done ("End Call").
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "start"},
+                {"id": "greet", "type": "agent", "data": {"prompt": "hi", "name": "Greeting"}},
+                {"id": "done", "type": "end", "data": {"name": "End Call"}}
+            ],
+            "edges": [
+                {"id": "e1", "source": "s", "target": "greet"},
+                {"id": "e2", "source": "greet", "target": "done", "label": "Finish"}
+            ]
+        });
+        let mut eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        // Construction records the active node (display name from `data.name`).
+        assert_eq!(eng.visited_nodes(), ["Greeting".to_string()]);
+        // Transition to the terminal node appends it. The transition name is the
+        // slugified edge label ("Finish" → "finish").
+        assert!(matches!(eng.on_transition("finish"), Action::End));
+        assert_eq!(
+            eng.visited_nodes(),
+            ["Greeting".to_string(), "End Call".to_string()]
+        );
+        // Re-seating onto an already-visited node must NOT duplicate it.
+        eng.set_current_node("greet").unwrap();
+        assert_eq!(
+            eng.visited_nodes(),
+            ["Greeting".to_string(), "End Call".to_string()],
+            "first-visit dedup"
+        );
+    }
+
+    #[test]
+    fn editor_authored_start_call_stays_active_with_its_prompt() {
+        // The catalog's `startCall` carries a prompt — must NOT be skipped.
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "Hi {{name}}!"}},
+                {"id": "e", "type": "endCall", "data": {"prompt": "Bye."}}
+            ],
+            "edges": [
+                {"id": "x", "source": "s", "target": "e", "label": "done"}
+            ]
+        });
+        let mut seed = Map::new();
+        seed.insert("name".into(), json!("Sam"));
+        let eng = Engine::new(&spec, json!({}), seed).unwrap();
+        assert_eq!(
+            eng.current_node(),
+            "s",
+            "start node with prompt must remain active"
+        );
+        assert!(
+            !eng.is_finished(),
+            "session must not be finished on creation"
+        );
+        assert_eq!(eng.current_prompt().system_prompt, "Hi Sam!");
+    }
+
+    #[test]
+    fn set_current_node_restores_persisted_state() {
+        let mut eng = Engine::new(&sample(), json!({}), Map::new()).unwrap();
+        // Fresh engine auto-advances past start (no prompt) to "greet".
+        assert_eq!(eng.current_node(), "greet");
+        // Simulate a persisted snapshot landing on "done"; the resume must
+        // honor it instead of re-running auto-advance.
+        eng.set_current_node("done").unwrap();
+        assert_eq!(eng.current_node(), "done");
+        assert!(eng.is_finished());
+        // Unknown node ids are rejected.
+        assert!(matches!(
+            eng.set_current_node("nope"),
+            Err(EngineError::UnknownNode(_))
+        ));
+    }
+
+    #[test]
+    fn global_directive_is_prepended_and_transition_criteria_used() {
+        let spec = json!({
+            "nodes": [
+                {"id": "g", "type": "globalNode", "data": {"prompt": "You are {{brand}} support."}},
+                {"id": "s", "type": "startCall", "data": {"prompt": "Hi, how can I help?"}},
+                {"id": "book", "type": "agentNode", "data": {"prompt": "Booking flow."}},
+                {"id": "done", "type": "endCall", "data": {"prompt": "Bye."}}
+            ],
+            "edges": [
+                {"id": "e1", "source": "s", "target": "book", "label": "Book",
+                 "data": {"condition": "Caller wants to book an appointment"}},
+                {"id": "e2", "source": "s", "target": "done", "label": "Done",
+                 "data": {"add_global_prompt": true}}
+            ]
+        });
+        let mut seed = Map::new();
+        seed.insert("brand".into(), json!("Acme"));
+        let eng = Engine::new(&spec, json!({}), seed).unwrap();
+        let p = eng.current_prompt();
+        // Global persona prepended (rendered), then the node prompt.
+        assert_eq!(
+            p.system_prompt,
+            "You are Acme support.\n\nHi, how can I help?"
+        );
+        // The edge's `condition` becomes the LLM-facing description; name is the
+        // slugified label.
+        let book = p.transitions.iter().find(|t| t.name == "book").unwrap();
+        assert_eq!(
+            book.description.as_deref(),
+            Some("Caller wants to book an appointment")
+        );
+        // No condition → falls back to the label.
+        let done = p.transitions.iter().find(|t| t.name == "done").unwrap();
+        assert_eq!(done.description.as_deref(), Some("Done"));
+    }
+
+    #[test]
+    fn node_can_opt_out_of_global_directive() {
+        let spec = json!({
+            "nodes": [
+                {"id": "g", "type": "globalNode", "data": {"prompt": "Persona."}},
+                {"id": "s", "type": "startCall", "data": {"prompt": "Body.", "add_global_prompt": false}},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "x"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        assert_eq!(eng.current_prompt().system_prompt, "Body.");
+    }
+
+    #[test]
+    fn extraction_spec_reads_node_config() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {
+                    "prompt": "Ask budget.",
+                    "extraction_enabled": true,
+                    "extraction_prompt": "Capture budget and timeline.",
+                    "extraction_variables": [
+                        {"name": "budget", "type": "number", "prompt": "monthly budget in USD"},
+                        {"name": "wants_demo", "type": "boolean"},
+                        {"name": "company"}
+                    ]
+                }},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "x"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        let ex = eng.extraction_spec().expect("extraction enabled");
+        assert_eq!(ex.prompt.as_deref(), Some("Capture budget and timeline."));
+        assert_eq!(ex.variables.len(), 3);
+        assert_eq!(ex.variables[0].name, "budget");
+        assert_eq!(ex.variables[0].var_type, VarType::Number);
+        assert_eq!(
+            ex.variables[0].hint.as_deref(),
+            Some("monthly budget in USD")
+        );
+        assert_eq!(ex.variables[1].var_type, VarType::Boolean);
+        // `company` omits type/hint → defaults.
+        assert_eq!(ex.variables[2].var_type, VarType::String);
+        assert!(ex.variables[2].hint.is_none());
+    }
+
+    #[test]
+    fn tool_refs_reads_node_tool_uuids() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi", "tool_uuids": ["t-1", "t-2"]}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "z", "source": "s", "target": "e"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        assert_eq!(eng.tool_refs(), vec!["t-1".to_string(), "t-2".to_string()]);
+    }
+
+    #[test]
+    fn tool_refs_empty_when_absent() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi"}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "z", "source": "s", "target": "e"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        assert!(eng.tool_refs().is_empty());
+    }
+
+    #[test]
+    fn document_refs_reads_node_document_uuids() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi", "document_uuids": ["d-1", "d-2"]}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "z", "source": "s", "target": "e"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        assert_eq!(
+            eng.document_refs(),
+            vec!["d-1".to_string(), "d-2".to_string()]
+        );
+        // Absent → empty.
+        let spec2 = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi"}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "z", "source": "s", "target": "e"}]
+        });
+        assert!(Engine::new(&spec2, json!({}), Map::new())
+            .unwrap()
+            .document_refs()
+            .is_empty());
+    }
+
+    #[test]
+    fn extraction_spec_none_when_disabled_or_empty() {
+        // disabled
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi", "extraction_variables": [{"name": "x"}]}},
+                {"id": "e", "type": "endCall"}
+            ],
+            "edges": [{"id": "z", "source": "s", "target": "e"}]
+        });
+        assert!(Engine::new(&spec, json!({}), Map::new())
+            .unwrap()
+            .extraction_spec()
+            .is_none());
+        // enabled but no variables
+        let spec2 = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi", "extraction_enabled": true}},
+                {"id": "e", "type": "endCall"}
+            ],
+            "edges": [{"id": "z", "source": "s", "target": "e"}]
+        });
+        assert!(Engine::new(&spec2, json!({}), Map::new())
+            .unwrap()
+            .extraction_spec()
+            .is_none());
+    }
+
+    #[test]
+    fn var_interpolate_nested_fallback_and_json() {
+        let mut vars = Map::new();
+        vars.insert("name".into(), json!("Sam"));
+        vars.insert(
+            "customer".into(),
+            json!({ "contact": { "email": "s@x.io" }, "tags": ["vip", "new"] }),
+        );
+        vars.insert("empty".into(), json!(""));
+        vars.insert("count".into(), json!(3));
+
+        // flat + nested dot-path
+        assert_eq!(var_interpolate("Hi {{name}}", &vars), "Hi Sam");
+        assert_eq!(
+            var_interpolate("{{customer.contact.email}}", &vars),
+            "s@x.io"
+        );
+        // array index in a path
+        assert_eq!(var_interpolate("{{customer.tags.0}}", &vars), "vip");
+        // object/array values render as JSON
+        assert_eq!(
+            var_interpolate("{{customer.tags}}", &vars),
+            r#"["vip","new"]"#
+        );
+        // scalar
+        assert_eq!(var_interpolate("n={{count}}", &vars), "n=3");
+        // fallbacks: missing, empty-string, and the legacy `fallback:` form
+        assert_eq!(var_interpolate("Hi {{missing | there}}", &vars), "Hi there");
+        assert_eq!(var_interpolate("Hi {{empty | there}}", &vars), "Hi there");
+        assert_eq!(
+            var_interpolate("Hi {{missing | fallback:friend}}", &vars),
+            "Hi friend"
+        );
+        // present value beats the fallback
+        assert_eq!(var_interpolate("Hi {{name | there}}", &vars), "Hi Sam");
+        // missing with no fallback → empty
+        assert_eq!(var_interpolate("[{{nope}}]", &vars), "[]");
+        // literal \n becomes a newline
+        assert_eq!(var_interpolate("a\\nb", &vars), "a\nb");
+        // an unterminated placeholder is left literal
+        assert_eq!(var_interpolate("a {{ b", &vars), "a {{ b");
+    }
+
+    #[test]
+    fn var_interpolate_value_recurses_json_template() {
+        let mut vars = Map::new();
+        vars.insert("id".into(), json!("c-42"));
+        vars.insert("city".into(), json!("Austin"));
+        let template = json!({
+            "url": "https://api.test/customers/{{id}}",
+            "body": { "where": ["{{city}}", "fixed"], "note": "hi {{missing | n/a}}" },
+            "keep": 7
+        });
+        let out = var_interpolate_value(&template, &vars);
+        assert_eq!(out["url"], "https://api.test/customers/c-42");
+        assert_eq!(out["body"]["where"][0], "Austin");
+        assert_eq!(out["body"]["where"][1], "fixed");
+        assert_eq!(out["body"]["note"], "hi n/a");
+        assert_eq!(out["keep"], 7); // non-string leaves pass through
+    }
+
+    #[test]
+    fn var_interpolate_resolves_time_builtins() {
+        use chrono::{TimeZone, Utc};
+        // 2024-01-05 14:30:00 UTC is a Friday.
+        let now = Utc.with_ymd_and_hms(2024, 1, 5, 14, 30, 0).unwrap();
+        let vars = Map::new();
+
+        assert_eq!(
+            var_interpolate_at("{{current_time}}", &vars, now),
+            "2024-01-05 14:30 UTC"
+        );
+        assert_eq!(
+            var_interpolate_at("{{current_date}}", &vars, now),
+            "2024-01-05"
+        );
+        assert_eq!(
+            var_interpolate_at("{{current_weekday}}", &vars, now),
+            "Friday"
+        );
+
+        // Local time in a named TZ: 14:30 UTC = 09:30 EST (UTC-5 in January).
+        assert_eq!(
+            var_interpolate_at("{{current_time_America/New_York}}", &vars, now),
+            "2024-01-05 09:30 EST"
+        );
+        assert_eq!(
+            var_interpolate_at("{{current_weekday_America/New_York}}", &vars, now),
+            "Friday"
+        );
+
+        // Embedded in a sentence + mixed with a normal variable.
+        let mut v = Map::new();
+        v.insert("name".into(), json!("Sam"));
+        assert_eq!(
+            var_interpolate_at("Hi {{name}}, it's {{current_weekday}}.", &v, now),
+            "Hi Sam, it's Friday."
+        );
+
+        // An unknown timezone is not a valid builtin → renders empty (falls
+        // through to variable resolution, which finds nothing).
+        assert_eq!(
+            var_interpolate_at("{{current_time_Not/AZone}}", &vars, now),
+            ""
+        );
+        // A real variable named like a builtin-prefix is unaffected.
+        let mut v2 = Map::new();
+        v2.insert("current_year".into(), json!("2024"));
+        assert_eq!(var_interpolate_at("{{current_year}}", &v2, now), "2024");
+    }
+
+    #[test]
+    fn var_interpolate_resolves_greeting_phrase() {
+        use chrono::{TimeZone, Utc};
+        let vars = Map::new();
+        // Bare form defaults to Asia/Singapore (UTC+8). Pick UTC instants so the
+        // SG wall-clock hour lands squarely in each bucket.
+        // 02:30 UTC = 10:30 SGT → morning.
+        let morning = Utc.with_ymd_and_hms(2024, 1, 5, 2, 30, 0).unwrap();
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, morning),
+            "Good morning"
+        );
+        // 06:00 UTC = 14:00 SGT → afternoon.
+        let afternoon = Utc.with_ymd_and_hms(2024, 1, 5, 6, 0, 0).unwrap();
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, afternoon),
+            "Good afternoon"
+        );
+        // 11:00 UTC = 19:00 SGT → evening.
+        let evening = Utc.with_ymd_and_hms(2024, 1, 5, 11, 0, 0).unwrap();
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, evening),
+            "Good evening"
+        );
+        // 18:00 UTC = 02:00 SGT → late night → neutral "Hello".
+        let night = Utc.with_ymd_and_hms(2024, 1, 5, 18, 0, 0).unwrap();
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, night),
+            "Hello"
+        );
+
+        // Bucket boundaries (SGT): 05:00 is morning, 04:59 is night; 12:00 is
+        // afternoon; 17:00 is evening; 22:00 is night.
+        let five_sgt = Utc.with_ymd_and_hms(2024, 1, 4, 21, 0, 0).unwrap(); // 05:00 SGT next day
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, five_sgt),
+            "Good morning"
+        );
+        let noon_sgt = Utc.with_ymd_and_hms(2024, 1, 5, 4, 0, 0).unwrap(); // 12:00 SGT
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, noon_sgt),
+            "Good afternoon"
+        );
+        let five_pm_sgt = Utc.with_ymd_and_hms(2024, 1, 5, 9, 0, 0).unwrap(); // 17:00 SGT
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, five_pm_sgt),
+            "Good evening"
+        );
+        let ten_pm_sgt = Utc.with_ymd_and_hms(2024, 1, 5, 14, 0, 0).unwrap(); // 22:00 SGT
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, ten_pm_sgt),
+            "Hello"
+        );
+
+        // `_<IANA TZ>` suffix overrides the default. 14:00 UTC = 09:00 EST → morning.
+        let now = Utc.with_ymd_and_hms(2024, 1, 5, 14, 0, 0).unwrap();
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase_America/New_York}}", &vars, now),
+            "Good morning"
+        );
+        // Same instant is 22:00 SGT → bare form is "Hello".
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}", &vars, now),
+            "Hello"
+        );
+
+        // Embedded in a greeting alongside a normal variable.
+        let mut v = Map::new();
+        v.insert("first_name".into(), json!("Sam"));
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase}}, {{first_name}}!", &v, evening),
+            "Good evening, Sam!"
+        );
+
+        // A bad timezone suffix is not a valid builtin → renders empty.
+        assert_eq!(
+            var_interpolate_at("{{greeting_phrase_Not/AZone}}", &vars, now),
+            ""
+        );
+    }
+
+    #[test]
+    fn transition_reaches_terminal() {
+        let eng_spec = sample();
+        let mut eng = Engine::new(&eng_spec, json!({}), Map::new()).unwrap();
+        let names: Vec<_> = eng
+            .current_prompt()
+            .transitions
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+        assert_eq!(names, vec!["finish"]);
+        let action = eng.on_transition("finish");
+        assert!(matches!(action, Action::End));
+        assert!(eng.is_finished());
+    }
+
+    #[test]
+    fn current_node_info_reports_id_name_and_interrupt() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi", "allow_interrupt": true}},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "Finish"}]
+        });
+        let mut eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        let info = eng.current_node_info();
+        assert_eq!(info.id, "s");
+        assert!(!info.name.is_empty());
+        assert_eq!(
+            info.allow_interrupt,
+            Some(true),
+            "reads allow_interrupt from node data"
+        );
+        // The accessor follows the engine after a transition; the end node has no flag.
+        let tname = eng.current_prompt().transitions[0].name.clone();
+        let _ = eng.on_transition(&tname);
+        let info2 = eng.current_node_info();
+        assert_eq!(info2.id, "done");
+        assert_eq!(info2.allow_interrupt, None, "absent flag → None");
+    }
+
+    // ── agent-driven transferCall ──────────────────────────
+
+    fn transfer_spec() -> Value {
+        json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {
+                    "prompt": "Hi {{name}}.",
+                    "transfer_targets": [
+                        {"target_phone": "+918760036560", "target_name": "Support",
+                         "description": "Escalate {{name}} to a human", "say": "Hold for {{name}}."}
+                    ]
+                }},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "x"}]
+        })
+    }
+
+    #[test]
+    fn transfer_target_exposed_with_pinned_number_and_interpolated_copy() {
+        let mut seed = Map::new();
+        seed.insert("name".into(), json!("Sam"));
+        let eng = Engine::new(&transfer_spec(), json!({}), seed).unwrap();
+        let p = eng.current_prompt();
+        assert_eq!(p.transfer_targets.len(), 1);
+        let t = &p.transfer_targets[0];
+        assert_eq!(
+            t.name, "transfer_call",
+            "default function name when unnamed"
+        );
+        assert_eq!(t.target_phone, "+918760036560");
+        assert_eq!(t.target_name.as_deref(), Some("Support"));
+        // say/description ARE var-interpolated (parity with prompts)…
+        assert_eq!(t.say.as_deref(), Some("Hold for Sam."));
+        assert_eq!(t.description.as_deref(), Some("Escalate Sam to a human"));
+        // …and the system prompt gains an explicit escalation directive naming the fn.
+        assert!(
+            p.system_prompt.contains("[Human escalation]")
+                && p.system_prompt.contains("`transfer_call`"),
+            "system prompt must tell the model it can transfer: {:?}",
+            p.system_prompt
+        );
+    }
+
+    #[test]
+    fn on_transfer_returns_pinned_number_else_stays() {
+        let eng = Engine::new(&transfer_spec(), json!({}), Map::new()).unwrap();
+        match eng.on_transfer("transfer_call") {
+            Action::Transfer {
+                target_phone,
+                target_name,
+                say,
+                mode,
+            } => {
+                assert_eq!(target_phone, "+918760036560");
+                assert_eq!(target_name.as_deref(), Some("Support"));
+                assert_eq!(say.as_deref(), Some("Hold for .")); // {{name}} missing + no fallback → empty
+                assert_eq!(
+                    mode,
+                    TransferMode::Cold,
+                    "default mode is cold when omitted"
+                );
+            }
+            other => panic!("expected Transfer, got {other:?}"),
+        }
+        // Unknown name → Stay (no transfer); engine does not advance.
+        assert!(matches!(eng.on_transfer("nope"), Action::Stay));
+        assert_eq!(
+            eng.current_node(),
+            "s",
+            "transfer must not advance the node"
+        );
+    }
+
+    #[test]
+    fn transfer_mode_warm_round_trips_else_defaults_cold() {
+        // `mode:"warm"` opts into warm transfer; anything else (or omitted) is cold.
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {
+                    "prompt": "Hi.",
+                    "transfer_targets": [
+                        {"name": "warm_xfer", "target_phone": "+918760036560", "mode": "warm"},
+                        {"name": "cold_xfer", "target_phone": "+918760036561", "mode": "cold"},
+                        {"name": "default_xfer", "target_phone": "+918760036562"}
+                    ]
+                }},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "x"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        let by = |name: &str| {
+            eng.current_prompt()
+                .transfer_targets
+                .into_iter()
+                .find(|t| t.name == name)
+                .unwrap()
+                .mode
+        };
+        assert_eq!(by("warm_xfer"), TransferMode::Warm);
+        assert_eq!(by("cold_xfer"), TransferMode::Cold);
+        assert_eq!(
+            by("default_xfer"),
+            TransferMode::Cold,
+            "omitted mode defaults cold"
+        );
+        // and it threads through on_transfer
+        match eng.on_transfer("warm_xfer") {
+            Action::Transfer { mode, .. } => assert_eq!(mode, TransferMode::Warm),
+            other => panic!("expected warm Transfer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transfer_target_phone_is_never_interpolated() {
+        // Even if an operator typo'd a placeholder into target_phone, it stays
+        // LITERAL — the conversation can never rewrite the dialed number.
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {
+                    "prompt": "Hi.",
+                    "transfer_targets": [{"target_phone": "{{evil}}"}]
+                }},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "x"}]
+        });
+        let mut seed = Map::new();
+        seed.insert("evil".into(), json!("+19999999999"));
+        let eng = Engine::new(&spec, json!({}), seed).unwrap();
+        assert_eq!(
+            eng.current_prompt().transfer_targets[0].target_phone,
+            "{{evil}}"
+        );
+    }
+
+    #[test]
+    fn empty_target_phone_entries_are_dropped() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {
+                    "prompt": "Hi.",
+                    "transfer_targets": [
+                        {"target_phone": "  "},
+                        {"name": "Sales Line", "target_phone": "+918760036560"}
+                    ]
+                }},
+                {"id": "done", "type": "endCall", "data": {}}
+            ],
+            "edges": [{"id": "e", "source": "s", "target": "done", "label": "x"}]
+        });
+        let eng = Engine::new(&spec, json!({}), Map::new()).unwrap();
+        let targets = eng.current_prompt().transfer_targets;
+        assert_eq!(targets.len(), 1, "blank-number entry dropped");
+        assert_eq!(targets[0].name, "sales_line", "operator name is slugified");
+        assert_eq!(targets[0].target_phone, "+918760036560");
+    }
+}

--- a/flowcat-agent/src/graph.rs
+++ b/flowcat-agent/src/graph.rs
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Workflow graph model. An agent is authored as a node/edge graph (e.g. in a
+//! React Flow editor) and persisted as `graph_spec` JSON. This parses that JSON
+//! into a validated directed graph the engine can traverse.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GraphError {
+    #[error("graph has no start node")]
+    NoStart,
+    #[error("edge references unknown node: {0}")]
+    DanglingEdge(String),
+    #[error("malformed graph spec: {0}")]
+    Malformed(String),
+}
+
+/// Node roles the engine understands. Unknown types are preserved as `Other`
+/// so authoring is not blocked on engine support.
+///
+/// An editor authors node `type` using the catalog names
+/// (`startCall`/`agentNode`/`endCall`), while hand-written graphs and the
+/// engine's own tests use the bare `start`/`agent`/`end` roles.
+/// The aliases accept both so an editor-built graph runs without a translation
+/// layer. The catalog's `trigger`/`webhook`/`qa`/`tuner` names are already
+/// snake_case and map to their own kinds (so their edge-cardinality rules can be
+/// validated); only genuinely unknown types fall through to `Other`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeKind {
+    #[serde(alias = "startCall")]
+    Start,
+    #[serde(alias = "agentNode")]
+    Agent,
+    #[serde(alias = "endCall")]
+    End,
+    /// The single (optional) persona/tone node whose prompt is prepended to
+    /// every node that opts in via `add_global_prompt`. Carries no edges, so it
+    /// is never traversed — the engine reads its prompt when composing a turn.
+    #[serde(alias = "globalNode")]
+    Global,
+    /// Inbound entry point (no incoming edges). Inert in the engine for now, but
+    /// its cardinality is validated.
+    Trigger,
+    /// Side-effect HTTP node — modelled as isolated (no edges) per the catalog.
+    Webhook,
+    /// Post-call review/QA node — isolated.
+    Qa,
+    /// Agent-tuner export node — isolated.
+    Tuner,
+    #[serde(other)]
+    Other,
+}
+
+/// Edge-cardinality bounds for a node kind (`None` = unbounded). The single
+/// source for the per-node-type rules an editor can surface as a catalog.
+struct EdgeBounds {
+    min_in: Option<usize>,
+    max_in: Option<usize>,
+    min_out: Option<usize>,
+    max_out: Option<usize>,
+}
+
+impl NodeKind {
+    fn edge_bounds(&self) -> EdgeBounds {
+        // (min_in, max_in, min_out, max_out)
+        let (min_in, max_in, min_out, max_out) = match self {
+            // Entry points: no incoming, outgoing unbounded.
+            NodeKind::Start | NodeKind::Trigger => (None, Some(0), None, None),
+            // Agent: at least one incoming; outgoing unbounded.
+            NodeKind::Agent => (Some(1), None, None, None),
+            // End: at least one incoming; no outgoing.
+            NodeKind::End => (Some(1), None, Some(0), Some(0)),
+            // Isolated nodes: no edges at all.
+            NodeKind::Global | NodeKind::Webhook | NodeKind::Qa | NodeKind::Tuner => {
+                (Some(0), Some(0), Some(0), Some(0))
+            }
+            // Unknown type — don't constrain (authoring isn't blocked).
+            NodeKind::Other => (None, None, None, None),
+        };
+        EdgeBounds {
+            min_in,
+            max_in,
+            min_out,
+            max_out,
+        }
+    }
+
+    /// Human label used in validation messages.
+    fn label(&self) -> &'static str {
+        match self {
+            NodeKind::Start => "Start",
+            NodeKind::Agent => "Agent",
+            NodeKind::End => "End",
+            NodeKind::Global => "Global",
+            NodeKind::Trigger => "Trigger",
+            NodeKind::Webhook => "Webhook",
+            NodeKind::Qa => "QA",
+            NodeKind::Tuner => "Tuner",
+            NodeKind::Other => "Node",
+        }
+    }
+}
+
+/// A single graph-validation error in the shape the workflow editor consumes:
+/// `kind` (`"node"`/`"edge"`/`"graph"`) + the offending `id` lets the editor
+/// highlight the node/edge; `message` is the human-readable reason. Graph-level
+/// errors (no start node, dangling edge) carry no `id`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationError {
+    pub kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: String,
+    #[serde(rename = "type", default = "default_kind")]
+    pub kind: NodeKind,
+    #[serde(default)]
+    pub data: serde_json::Value,
+}
+
+fn default_kind() -> NodeKind {
+    NodeKind::Other
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Edge {
+    pub id: String,
+    pub source: String,
+    pub target: String,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub data: serde_json::Value,
+}
+
+/// Parsed, validated workflow graph with adjacency precomputed.
+#[derive(Debug, Clone)]
+pub struct Graph {
+    pub nodes: HashMap<String, Node>,
+    pub edges: Vec<Edge>,
+    pub start_id: String,
+    /// The global-directive node, if the workflow has one.
+    global_id: Option<String>,
+    adjacency: HashMap<String, Vec<usize>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawGraph {
+    #[serde(default)]
+    nodes: Vec<Node>,
+    #[serde(default)]
+    edges: Vec<Edge>,
+}
+
+impl Graph {
+    /// Parse and validate a `graph_spec` JSON document.
+    pub fn parse(spec: &serde_json::Value) -> Result<Self, GraphError> {
+        let raw: RawGraph = serde_json::from_value(spec.clone())
+            .map_err(|e| GraphError::Malformed(e.to_string()))?;
+
+        let mut nodes = HashMap::new();
+        for n in raw.nodes {
+            nodes.insert(n.id.clone(), n);
+        }
+
+        let start_id = nodes
+            .values()
+            .find(|n| n.kind == NodeKind::Start)
+            .map(|n| n.id.clone())
+            .ok_or(GraphError::NoStart)?;
+
+        let global_id = nodes
+            .values()
+            .find(|n| n.kind == NodeKind::Global)
+            .map(|n| n.id.clone());
+
+        let mut adjacency: HashMap<String, Vec<usize>> = HashMap::new();
+        for (idx, e) in raw.edges.iter().enumerate() {
+            if !nodes.contains_key(&e.source) {
+                return Err(GraphError::DanglingEdge(e.source.clone()));
+            }
+            if !nodes.contains_key(&e.target) {
+                return Err(GraphError::DanglingEdge(e.target.clone()));
+            }
+            adjacency.entry(e.source.clone()).or_default().push(idx);
+        }
+
+        Ok(Self {
+            nodes,
+            edges: raw.edges,
+            start_id,
+            global_id,
+            adjacency,
+        })
+    }
+
+    /// Per-node-type edge-cardinality violations,
+    /// driven by [`NodeKind::edge_bounds`] (the catalog rules: start/trigger take
+    /// no incoming; agent needs ≥1 incoming; end needs ≥1 incoming and no
+    /// outgoing; global/webhook/qa/tuner are isolated). Returns structured
+    /// [`ValidationError`]s (empty ⇒ valid) so the editor can highlight the
+    /// offending node. A *validation* concern, separate from `parse` (which stays
+    /// lenient so an in-progress draft can still be run).
+    pub fn cardinality_errors(&self) -> Vec<ValidationError> {
+        let mut in_deg: HashMap<&str, usize> = HashMap::new();
+        let mut out_deg: HashMap<&str, usize> = HashMap::new();
+        for id in self.nodes.keys() {
+            in_deg.insert(id.as_str(), 0);
+            out_deg.insert(id.as_str(), 0);
+        }
+        for e in &self.edges {
+            *out_deg.entry(e.source.as_str()).or_insert(0) += 1;
+            *in_deg.entry(e.target.as_str()).or_insert(0) += 1;
+        }
+
+        let mut errors = Vec::new();
+        for node in self.nodes.values() {
+            let id = node.id.as_str();
+            let i = in_deg.get(id).copied().unwrap_or(0);
+            let o = out_deg.get(id).copied().unwrap_or(0);
+            let b = node.kind.edge_bounds();
+            let label = node.kind.label();
+
+            let mut msgs: Vec<String> = Vec::new();
+            if let Some(m) = b.min_in {
+                if i < m {
+                    msgs.push(format!("must have at least {m} incoming edge(s)"));
+                }
+            }
+            if let Some(m) = b.max_in {
+                if i > m {
+                    msgs.push(if m == 0 {
+                        "cannot have incoming edges".to_string()
+                    } else {
+                        format!("must have at most {m} incoming edge(s)")
+                    });
+                }
+            }
+            if let Some(m) = b.min_out {
+                if o < m {
+                    msgs.push(format!("must have at least {m} outgoing edge(s)"));
+                }
+            }
+            if let Some(m) = b.max_out {
+                if o > m {
+                    msgs.push(if m == 0 {
+                        "cannot have outgoing edges".to_string()
+                    } else {
+                        format!("must have at most {m} outgoing edge(s)")
+                    });
+                }
+            }
+            for msg in msgs {
+                errors.push(ValidationError {
+                    kind: "node",
+                    id: Some(node.id.clone()),
+                    message: format!("{label} node \"{id}\": {msg}"),
+                });
+            }
+        }
+        errors
+    }
+
+    /// The global node's raw (un-rendered) `prompt`, if the workflow has a
+    /// global node carrying one. Callers render it against the run variables.
+    pub fn global_prompt(&self) -> Option<&str> {
+        let id = self.global_id.as_ref()?;
+        self.nodes
+            .get(id)
+            .and_then(|n| n.data.get("prompt"))
+            .and_then(|v| v.as_str())
+    }
+
+    /// Outgoing edges from a node, in declaration order.
+    pub fn outgoing(&self, node_id: &str) -> Vec<&Edge> {
+        self.adjacency
+            .get(node_id)
+            .map(|idxs| idxs.iter().map(|&i| &self.edges[i]).collect())
+            .unwrap_or_default()
+    }
+
+    pub fn node(&self, id: &str) -> Option<&Node> {
+        self.nodes.get(id)
+    }
+
+    /// The node's human display name for observability (`nodes_visited`), read
+    /// from the editor node `data` (`name`/`label`/`title`), falling back to the
+    /// raw id when the node carries no label.
+    pub fn node_name(&self, id: &str) -> String {
+        self.node(id)
+            .and_then(|n| {
+                ["name", "label", "title"]
+                    .iter()
+                    .find_map(|k| n.data.get(*k).and_then(|v| v.as_str()))
+            })
+            .map(str::to_string)
+            .unwrap_or_else(|| id.to_string())
+    }
+
+    pub fn is_terminal(&self, id: &str) -> bool {
+        self.node(id)
+            .map(|n| n.kind == NodeKind::End)
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_minimal_graph() {
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "start", "data": {}},
+                {"id": "a", "type": "agent", "data": {"prompt": "hi"}},
+                {"id": "e", "type": "end", "data": {}}
+            ],
+            "edges": [
+                {"id": "e1", "source": "s", "target": "a"},
+                {"id": "e2", "source": "a", "target": "e", "label": "done"}
+            ]
+        });
+        let g = Graph::parse(&spec).expect("valid graph");
+        assert_eq!(g.start_id, "s");
+        assert_eq!(g.outgoing("a").len(), 1);
+        assert!(g.is_terminal("e"));
+    }
+
+    #[test]
+    fn parses_editor_catalog_node_types() {
+        // Graph as the React Flow editor persists it (node-spec catalog names).
+        let spec = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {}},
+                {"id": "a", "type": "agentNode", "data": {"prompt": "hi"}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [
+                {"id": "e1", "source": "s", "target": "a"},
+                {"id": "e2", "source": "a", "target": "e", "label": "done"}
+            ]
+        });
+        let g = Graph::parse(&spec).expect("editor-authored graph parses");
+        assert_eq!(g.start_id, "s");
+        assert!(g.is_terminal("e"));
+        // `globalNode`/`trigger`/`webhook`/`qa`/`tuner` now resolve to their own
+        // kinds (so their cardinality is validated); a genuinely unknown type
+        // still stays inert (Other) rather than failing the parse.
+        assert_eq!(
+            serde_json::from_value::<NodeKind>(json!("globalNode")).unwrap(),
+            NodeKind::Global
+        );
+        assert_eq!(
+            serde_json::from_value::<NodeKind>(json!("trigger")).unwrap(),
+            NodeKind::Trigger
+        );
+        assert_eq!(
+            serde_json::from_value::<NodeKind>(json!("webhook")).unwrap(),
+            NodeKind::Webhook
+        );
+        assert_eq!(
+            serde_json::from_value::<NodeKind>(json!("madeUpType")).unwrap(),
+            NodeKind::Other
+        );
+    }
+
+    #[test]
+    fn cardinality_accepts_valid_graph_and_flags_violations() {
+        // start → agent → end is well-formed.
+        let ok = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {"prompt": "hi"}},
+                {"id": "a", "type": "agentNode", "data": {}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [
+                {"id": "e1", "source": "s", "target": "a"},
+                {"id": "e2", "source": "a", "target": "e"}
+            ]
+        });
+        assert!(Graph::parse(&ok).unwrap().cardinality_errors().is_empty());
+
+        // Violations: edge INTO start, an agent with no incoming, an edge OUT of
+        // end, and a global node wired into the graph.
+        let bad = json!({
+            "nodes": [
+                {"id": "g", "type": "globalNode", "data": {}},
+                {"id": "s", "type": "startCall", "data": {}},
+                {"id": "a", "type": "agentNode", "data": {}},
+                {"id": "orphan", "type": "agentNode", "data": {}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [
+                {"id": "x1", "source": "a", "target": "s"}, // into start (bad)
+                {"id": "x2", "source": "s", "target": "a"},
+                {"id": "x3", "source": "a", "target": "e"},
+                {"id": "x4", "source": "e", "target": "a"}, // out of end (bad)
+                {"id": "x5", "source": "g", "target": "a"}  // global wired (bad)
+            ]
+        });
+        let errs = Graph::parse(&bad).unwrap().cardinality_errors();
+        assert!(errs
+            .iter()
+            .any(|e| e.message.contains("Start") && e.message.contains("incoming")));
+        assert!(errs
+            .iter()
+            .any(|e| e.message.contains("End") && e.message.contains("outgoing")));
+        assert!(errs.iter().any(|e| e.message.contains("Global")));
+        assert!(errs
+            .iter()
+            .any(|e| e.message.contains("orphan") && e.message.contains("incoming")));
+        // Every node-level error carries the offending node id + kind for editor
+        // highlighting (no bare strings).
+        assert!(errs.iter().all(|e| e.kind == "node" && e.id.is_some()));
+    }
+
+    #[test]
+    fn cardinality_enforces_trigger_and_webhook_rules() {
+        // trigger = no incoming (like start); webhook/qa/tuner = isolated.
+        let bad = json!({
+            "nodes": [
+                {"id": "s", "type": "startCall", "data": {}},
+                {"id": "t", "type": "trigger", "data": {}},
+                {"id": "a", "type": "agentNode", "data": {}},
+                {"id": "w", "type": "webhook", "data": {}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [
+                {"id": "x1", "source": "s", "target": "a"},
+                {"id": "x2", "source": "a", "target": "t"}, // INTO trigger (bad)
+                {"id": "x3", "source": "a", "target": "w"}, // INTO webhook (bad — isolated)
+                {"id": "x4", "source": "a", "target": "e"}
+            ]
+        });
+        let errs = Graph::parse(&bad).unwrap().cardinality_errors();
+        assert!(
+            errs.iter()
+                .any(|e| e.id.as_deref() == Some("t") && e.message.contains("incoming")),
+            "trigger with an incoming edge must be flagged: {errs:?}"
+        );
+        assert!(
+            errs.iter()
+                .any(|e| e.id.as_deref() == Some("w") && e.message.contains("incoming")),
+            "webhook is isolated — an incoming edge must be flagged: {errs:?}"
+        );
+
+        // A trigger as a pure entry point (outgoing only) is valid.
+        let ok = json!({
+            "nodes": [
+                {"id": "t", "type": "trigger", "data": {}},
+                {"id": "s", "type": "startCall", "data": {}},
+                {"id": "a", "type": "agentNode", "data": {}},
+                {"id": "e", "type": "endCall", "data": {}}
+            ],
+            "edges": [
+                {"id": "x1", "source": "t", "target": "a"},
+                {"id": "x2", "source": "s", "target": "a"},
+                {"id": "x3", "source": "a", "target": "e"}
+            ]
+        });
+        assert!(Graph::parse(&ok).unwrap().cardinality_errors().is_empty());
+    }
+
+    #[test]
+    fn rejects_missing_start() {
+        let spec = json!({"nodes": [{"id": "a", "type": "agent"}], "edges": []});
+        assert!(matches!(Graph::parse(&spec), Err(GraphError::NoStart)));
+    }
+
+    #[test]
+    fn rejects_dangling_edge() {
+        let spec = json!({
+            "nodes": [{"id": "s", "type": "start"}],
+            "edges": [{"id": "x", "source": "s", "target": "ghost"}]
+        });
+        assert!(matches!(
+            Graph::parse(&spec),
+            Err(GraphError::DanglingEdge(_))
+        ));
+    }
+}

--- a/flowcat-agent/src/lib.rs
+++ b/flowcat-agent/src/lib.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! `flowcat-agent` — a declarative, graph-based conversation agent for Flowcat.
+//!
+//! Define an agent as a node/edge graph (the same `graph_spec` JSON an editor
+//! produces) instead of hand-writing an `AgentBrain` in Rust. The [`Engine`] is
+//! pure logic: parse the graph, track the active node, compose each turn's system
+//! prompt + the callable transitions, interpolate `{{variables}}`, and advance on
+//! a transition/tool call.
+//!
+//! With the `brain` feature (on by default) the crate also ships a
+//! `DeclarativeBrain`, a ready-to-use `flowcat_core::AgentBrain` backed by the
+//! engine — so a config-driven host can run an agent with no Rust agent code.
+//! Turn the feature off (`default-features = false`) to use the pure engine
+//! without depending on `flowcat-core`.
+
+#[cfg(feature = "brain")]
+pub mod brain;
+pub mod engine;
+pub mod graph;
+
+pub use engine::{
+    validate, validate_detailed, var_interpolate, var_interpolate_value, Action, Engine,
+    EngineError, ExtractionSpec, ExtractionVar, NodeInfo, NodePrompt, TransferMode, TransferTarget,
+    TransitionSpec, VarType,
+};
+pub use graph::{Edge, Graph, GraphError, Node, NodeKind, ValidationError};
+
+#[cfg(feature = "brain")]
+pub use brain::{DeclarativeBrain, END_CALL_TOOL};


### PR DESCRIPTION
## What

A new `flowcat-agent` crate: a declarative, graph-based conversation agent for Flowcat. Define an agent as a node/edge `graph_spec` (the shape a visual editor produces) instead of hand-writing an `AgentBrain` in Rust.

## Why

Embedding Flowcat today means implementing the `AgentBrain` trait by hand. `flowcat-agent` lets you describe an agent declaratively — nodes are conversation states with prompts, edges are transitions the model can call — lowering the barrier to building on Flowcat and giving config-driven hosts a turnkey brain.

## What's in it

- **`engine` + `graph`** — pure-logic graph decision engine: parse the graph, track the active node, compose each turn's system prompt + callable transitions, `{{variable}}` interpolation (with `{{current_time}}` / `{{greeting_phrase}}` time builtins and IANA timezones), variable extraction, and operator-pinned human-transfer targets.
- **`DeclarativeBrain`** — a turnkey `flowcat_core::AgentBrain` over the engine: each transition becomes a no-arg tool the model calls to take that edge, plus an always-present `endCall`.

## Design

- The `AgentBrain` adapter sits behind a **default-on `brain` feature**. With `default-features = false`, the pure engine builds with **no `flowcat-core` dependency** (only `serde`/`chrono`) — usable for graph validation/tooling on its own.
- **The default build stays dependency-free**: `flowcat-cli` pulls neither `flowcat-agent` nor `chrono`.

## Testing

- 37 tests (engine + graph + brain).
- `cargo clippy --all-targets -- -D warnings` clean — both default and `--no-default-features`.
- `cargo fmt --check` clean.

## Follow-ups (not in this PR)

- Generalize the human-transfer schema naming (e.g. `transfer_targets` → `escalation_targets`); deferred to avoid breaking existing graph specs.
