### PR TITLE
feat: config-driven server, provider factory, WebRTC playground + deploy (FR-2→FR-10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,11 @@ jobs:
         run: cargo test -p flowcat-transports --locked --features webrtc-str0m,ws,daily,livekit,local
       - name: flowcat-telephony (every serializer)
         run: cargo test -p flowcat-telephony --locked --features twilio,telnyx,exotel,vonage,genesys,asterisk,cloudonix,vobiz,dtmf-inband
+      # The config-driven server + the browser WebRTC playground are feature-gated
+      # (axum/tokio/str0m), so the default-features job above does not reach them.
+      # `webrtc` implies `server`, so this exercises both the HTTP server and the
+      # playground, plus the full provider connector set the binary can run.
+      - name: flowcat-server (server + webrtc playground)
+        run: |
+          cargo clippy -p flowcat-server --locked --features webrtc --all-targets -- -D warnings
+          cargo test -p flowcat-server --locked --features webrtc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ dependencies = [
  "flowcat-core",
  "flowcat-services",
  "flowcat-telephony",
+ "flowcat-transports",
  "futures-util",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,11 +269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -281,10 +285,17 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -303,6 +314,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -962,14 +974,20 @@ name = "flowcat-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
+ "flowcat-agent",
  "flowcat-core",
  "flowcat-services",
+ "flowcat-telephony",
+ "futures-util",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1791,6 +1809,15 @@ name = "lzma-rust2"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -2780,6 +2807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,6 +3326,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3331,11 +3370,15 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "flowcat-server"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "flowcat-core",
+ "flowcat-services",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "flowcat-services"
 version = "0.1.0"
 dependencies = [
@@ -2777,6 +2792,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,6 +3391,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "flowcat-transports", # str0m WebRTC / WS / Daily / local / avatar
     "flowcat-telephony",  # carrier serializers + DTMF
     "flowcat-agent",      # declarative graph agent (config-driven AgentBrain)
+    "flowcat-server",     # config-driven single-agent server (config + StaticSession)
     "flowcat-cli",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-stage build for the `flowcat-server` binary.
+#
+# Build arg FEATURES selects the flowcat-server Cargo feature set:
+#   server  (default) — the HTTP server + the full provider connector set
+#   webrtc            — server + the browser WebRTC playground (adds str0m)
+ARG FEATURES=server
+
+FROM rust:1-bookworm AS build
+ARG FEATURES
+WORKDIR /src
+# Build deps for the connector set: protobuf-compiler (Google/NVIDIA gRPC),
+# cmake + clang (local Whisper STT via whisper-rs).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends protobuf-compiler cmake clang \
+ && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN cargo build --release -p flowcat-server --features "${FEATURES}"
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/flowcat-server /usr/local/bin/flowcat-server
+# Mount your agent config here (see deploy/agent.example.yaml).
+ENV FLOWCAT_CONFIG=/etc/flowcat/agent.yaml
+EXPOSE 6210
+ENTRYPOINT ["flowcat-server"]

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,11 +8,12 @@ conversation" in about five minutes — no credentials, no accounts, no cloud.
 end-to-end, a real WebSocket media round-trip, and your conversation policy driven
 from Python over the `RemoteBrain` seam.
 
-**What it does _not_ get you (yet):** a live PSTN phone call. That needs a small
-*embedder* you wire to your carrier and control plane — [step 5](#5-from-here-to-a-live-phone-call)
-shows exactly what that piece is and where the live-verified path starts. We'd
-rather you hit a working demo in five minutes than a phone call that needs an hour
-of setup to fail.
+**Then, with one provider key:**
+[step 5](#5-talk-to-a-real-agent-in-your-browser-no-rust) runs a *real* agent you
+talk to in your browser — **no Rust** — via the `flowcat-server` binary + a YAML
+config. A live **PSTN** call adds your own *embedder* (carrier + control plane);
+[step 6](#6-carry-a-pstn-call-with-your-own-embedder) shows what that piece is and
+where the live-verified path starts.
 
 Everything in steps 1–4 is exercised in CI, so it runs on the first try.
 
@@ -130,11 +131,37 @@ state machine. A Rust embedder wires this in with `RemoteBrain::connect(...)`; s
 *functions* as model tools instead, see
 [`examples/python-mcp-tools`](examples/python-mcp-tools).
 
-## 5. From here to a live phone call
+## 5. Talk to a real agent in your browser (no Rust)
 
-The steps above run the runtime in isolation. A real inbound/outbound PSTN call
-adds the one piece Flowcat deliberately leaves to you — the **embedder**: a small
-host binary that
+Steps 1–4 are credential-free. To run a *real* agent end-to-end with **no Rust**,
+use the **`flowcat-server`** binary: define the agent in a YAML config and serve
+it; the browser playground (`--features webrtc`) lets you talk to it directly.
+
+You need one provider key — the live-verified path is **Gemini Live**, so set
+`GOOGLE_API_KEY` (a free key from [Google AI Studio](https://aistudio.google.com/)
+works):
+
+```bash
+cargo build --release -p flowcat-server --features webrtc
+GOOGLE_API_KEY=… ./target/release/flowcat-server --config deploy/agent.example.yaml
+```
+
+Open **<http://localhost:6210/>**, allow the microphone, click **Start call** —
+and you're talking to the agent defined in
+[`deploy/agent.example.yaml`](deploy/agent.example.yaml): a node/edge graph you
+edit, with no control plane and no database. The live transcript renders as you
+speak. The server resolves providers **by name** from the config and reads their
+keys from the environment; the full schema is in `flowcat-server/src/config.rs`.
+
+> Prefer telephony? Point a Plivo number's answer webhook at the server's
+> `/telephony/answer/plivo/{run_id}` and it bridges the media WebSocket. Or run
+> the whole thing in Docker: `docker compose -f deploy/docker-compose.yml up
+> --build` — see [`deploy/README.md`](deploy/README.md).
+
+## 6. Carry a PSTN call with your own embedder
+
+For full control — your own routing, control plane, and in-process brain logic —
+you write a small **embedder**: a host binary that
 
 - **terminates the call** — the native in-process `SipTransport` (SIP/RTP, no
   softswitch required), or a carrier WebSocket transport if you already run one;

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ pipeline model and the same provider breadth, packaged for teams that need to
 **own the stack** — self-hosted, auditable, and dense enough to run serious call
 volume per box. No pipecat code is vendored — see [`NOTICE`](NOTICE).
 
+**▶ Watch the overview:**
+
+[![Flowcat — overview video](https://img.youtube.com/vi/XuR4jfJofhg/hqdefault.jpg)](https://youtu.be/XuR4jfJofhg)
+
 **Status:** pre-1.0, building in the open.
 
 > **New here?** → **[`QUICKSTART.md`](QUICKSTART.md)** takes you from `git clone` to

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ pipeline model and the same provider breadth, packaged for teams that need to
 **own the stack** — self-hosted, auditable, and dense enough to run serious call
 volume per box. No pipecat code is vendored — see [`NOTICE`](NOTICE).
 
-**License:** Apache-2.0 ([`LICENSE`](LICENSE)) · **Status:** pre-1.0, building in
-the open.
+**Status:** pre-1.0, building in the open.
 
 > **New here?** → **[`QUICKSTART.md`](QUICKSTART.md)** takes you from `git clone` to
-> a running pipeline, a real WebSocket audio round-trip, and a Python-driven brain
-> in about five minutes — no credentials.
+> a running pipeline and a real audio round-trip in about five minutes (no
+> credentials), then to a **real agent you talk to in your browser** — define it in
+> YAML and run one binary (`flowcat-server`), no Rust required.
 
 ---
 
@@ -169,7 +169,28 @@ cargo run -p flowcat-cli -- pipeline           # in-process FrameProcessor pipel
 cargo run -p flowcat-cli -- ws-echo --loopback # real WebSocket PCM echo round-trip
 ```
 
-Embedding Flowcat in your own service, in three seams you implement:
+### Run an agent from a config — no Rust
+
+Don't want to embed Flowcat in a Rust binary? Run **`flowcat-server`**: describe
+one agent in a YAML/JSON config (a node/edge graph + the realtime or cascaded
+provider topology) and serve it over HTTP — no control plane, no database.
+
+```bash
+cargo build --release -p flowcat-server --features webrtc
+GOOGLE_API_KEY=… ./target/release/flowcat-server --config deploy/agent.example.yaml
+# open http://localhost:6210/ to talk to it (mic + live transcript), or bridge a
+# Plivo number to the server's /telephony/ws/plivo/{run_id}
+```
+
+Providers are selected **by name** from the config (the `flowcat-services`
+factory) and their keys come from the environment; the agent graph is run by
+`flowcat-agent`. A Dockerfile, compose file, sample config, and env template are
+in [`deploy/`](deploy/). The config schema lives in `flowcat-server/src/config.rs`.
+
+### Embed it in your own service
+
+For full control (custom routing, your own control plane, in-process brain logic),
+embed the library and implement three seams:
 
 - **`FrameProcessor` pipeline** — compose `transport.input() → vad → stt → llm →
   tts → transport.output()` (or a single realtime S2S model) into a `Pipeline`,
@@ -303,6 +324,7 @@ flowcat/
 ├── flowcat-transports/  # str0m WebRTC + Opus, WebSocket, Daily, LiveKit, local
 ├── flowcat-telephony/   # carrier FrameSerializers (Twilio/Telnyx/Plivo/…) + DTMF
 ├── flowcat-agent/       # declarative graph agent — a config-driven AgentBrain
+├── flowcat-server/      # config-driven single-agent server + browser playground
 ├── flowcat-cli/         # `flowcat` demo binary (DX / examples surface)
 ├── bench/               # the reproducible pipecat-vs-flowcat benchmark kit + RESULTS.md
 ├── bench-rs/            # standalone load-gen + framework micro-bench

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copy to `.env` (in this deploy/ dir) and fill the key(s) your topology uses.
+# Provider keys are read by flowcat-server as <PROVIDER>_API_KEY.
+
+GOOGLE_API_KEY=
+OPENAI_API_KEY=
+DEEPGRAM_API_KEY=
+CARTESIA_API_KEY=
+
+# Telephony only: the public https URL Plivo fetches the answer XML from.
+FLOWCAT_PUBLIC_URL=
+
+# WebRTC playground: the host IP str0m advertises as its ICE candidate — a
+# reachable LAN/public IP (NOT 0.0.0.0). Defaults to loopback for local use.
+FLOWCAT_WEBRTC_BIND_IP=127.0.0.1
+
+# Build the playground feature: set to `webrtc` (default `server`).
+FLOWCAT_FEATURES=server
+
+RUST_LOG=info

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,43 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Deploying `flowcat-server`
+
+`flowcat-server` runs **one agent** (defined in a YAML/JSON config) over HTTP —
+health probes, a Plivo media WebSocket + answer XML, and, with the `webrtc`
+feature, a browser playground at `/`. No control plane, no database.
+
+## Docker Compose
+
+```bash
+cp deploy/.env.example deploy/.env      # fill the key(s) your topology uses
+docker compose -f deploy/docker-compose.yml up --build
+```
+
+- Health: `curl localhost:6210/healthz` → `{"status":"ok"}`
+- Readiness: `curl localhost:6210/readyz` (200 once the topology's provider key is set)
+
+For the **browser playground** (str0m WebRTC), build the `webrtc` feature:
+
+```bash
+FLOWCAT_FEATURES=webrtc docker compose -f deploy/docker-compose.yml up --build
+# then open http://localhost:6210/  (set FLOWCAT_WEBRTC_BIND_IP to a reachable host IP)
+```
+
+## Without Docker
+
+```bash
+cargo build --release -p flowcat-server --features webrtc   # or just "server"
+GOOGLE_API_KEY=… ./target/release/flowcat-server --config deploy/agent.example.yaml
+```
+
+## Configuration
+
+- **Agent config** — see [`agent.example.yaml`](agent.example.yaml) and the schema
+  in `flowcat-server/src/config.rs` (agent graph, `realtime`/`cascaded` topology,
+  transport, bind).
+- **Provider keys** come from the environment as `<PROVIDER>_API_KEY` (e.g.
+  `GOOGLE_API_KEY`, `DEEPGRAM_API_KEY`), the Gemini family also accepts
+  `GOOGLE_API_KEY`. Keys are **never** read from the config file.
+
+> The build compiles the full provider connector set, so the build stage needs
+> `protobuf-compiler`, `cmake`, and `clang` (already installed in the Dockerfile)
+> for the gRPC + local-Whisper connectors. Trim `--features` to speed it up.

--- a/deploy/agent.example.yaml
+++ b/deploy/agent.example.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A minimal single-agent config for flowcat-server. Full schema:
+# flowcat-server/src/config.rs. Provider API keys are NOT here — they come from
+# the environment (GOOGLE_API_KEY, DEEPGRAM_API_KEY, …).
+agent:
+  graph_inline:
+    nodes:
+      - id: start
+        type: startCall
+        data: { prompt: "Hi! Thanks for calling. How can I help today?" }
+      - id: done
+        type: endCall
+        data: { prompt: "Thanks for calling. Goodbye!" }
+    edges:
+      - id: e1
+        source: start
+        target: done
+        label: "Wrap up"
+        data: { condition: "The caller is finished" }
+  seed_vars: {}
+
+topology:
+  mode: realtime # realtime (speech-to-speech) | cascaded (STT -> LLM -> TTS)
+  provider: gemini # realtime provider; needs GOOGLE_API_KEY
+  # model: gemini-2.0-flash
+  # For cascaded instead:
+  # mode: cascaded
+  # stt: { provider: deepgram, model: nova-3 }   # needs DEEPGRAM_API_KEY
+  # llm: { provider: openai, model: gpt-4o }     # needs OPENAI_API_KEY
+  # tts: { provider: cartesia, model: <voice> }  # needs CARTESIA_API_KEY
+
+transport:
+  kind: webrtc # webrtc (browser playground) | ws-plivo | sip
+
+server:
+  bind: "0.0.0.0:6210"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run flowcat-server in Docker. Copy .env.example to .env and fill the provider
+# key(s) your topology uses, then: docker compose -f deploy/docker-compose.yml up --build
+#
+# For the browser playground (str0m WebRTC), build with the `webrtc` feature:
+#   FLOWCAT_FEATURES=webrtc docker compose -f deploy/docker-compose.yml up --build
+services:
+  flowcat-server:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        FEATURES: ${FLOWCAT_FEATURES:-server}
+    image: flowcat-server:local
+    ports:
+      - "6210:6210"
+    environment:
+      # Provider keys — at least the one your topology uses (see .env.example).
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      DEEPGRAM_API_KEY: ${DEEPGRAM_API_KEY:-}
+      CARTESIA_API_KEY: ${CARTESIA_API_KEY:-}
+      # Telephony only: the public https URL Plivo fetches the answer XML from.
+      FLOWCAT_PUBLIC_URL: ${FLOWCAT_PUBLIC_URL:-}
+      # WebRTC playground: the host IP str0m advertises (reachable, not 0.0.0.0).
+      FLOWCAT_WEBRTC_BIND_IP: ${FLOWCAT_WEBRTC_BIND_IP:-127.0.0.1}
+      RUST_LOG: ${RUST_LOG:-info}
+    volumes:
+      - ./agent.example.yaml:/etc/flowcat/agent.yaml:ro

--- a/flowcat-core/src/sip/agent.rs
+++ b/flowcat-core/src/sip/agent.rs
@@ -21,9 +21,13 @@
 //! rsipstack owns *signaling only*. For each established call we hand-roll the
 //! media: bind a fresh RTP `UdpSocket`, put its address + our G.711 offer/answer
 //! in the SDP, parse the peer's SDP for their RTP address + chosen codec, and
-//! build a [`SipTransport`] (RTP ↔ `MediaIn`). The negotiated dialog's state
-//! channel is watched so a BYE / `Terminated` fires the transport's hangup token,
-//! which surfaces as [`MediaIn::Stop`](crate::transport::MediaIn::Stop).
+//! build a [`SipTransport`] (RTP ↔ `MediaIn`). A per-call supervisor
+//! ([`spawn_dialog_supervisor`]) bridges the two teardown directions: a peer BYE
+//! / `Terminated` fires the transport's hangup token (surfacing as
+//! [`MediaIn::Stop`](crate::transport::MediaIn::Stop)), while the agent ending the
+//! call (the `SipTransport` is dropped) makes the supervisor send a BYE to the
+//! peer. Either way it removes the dialog from the layer's map so dialogs can't
+//! leak across calls.
 //!
 //! ## What is gated on a live trunk
 //!
@@ -38,10 +42,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rsipstack::dialog::authenticate::Credential;
+use rsipstack::dialog::client_dialog::ClientInviteDialog;
 use rsipstack::dialog::dialog::{DialogState, DialogStateReceiver, DialogStateSender};
 use rsipstack::dialog::dialog_layer::DialogLayer;
 use rsipstack::dialog::invitation::InviteOption;
 use rsipstack::dialog::server_dialog::ServerInviteDialog;
+use rsipstack::dialog::DialogId;
 use rsipstack::sip as rsip;
 use rsipstack::sip::prelude::HeadersExt;
 use rsipstack::transaction::endpoint::EndpointInnerRef;
@@ -49,7 +55,7 @@ use rsipstack::transaction::TransactionReceiver;
 use rsipstack::transport::{udp::UdpConnection, TransportLayer};
 use rsipstack::EndpointBuilder;
 use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio_util::sync::CancellationToken;
 
 use crate::error::FlowcatError;
@@ -71,6 +77,15 @@ pub const DEFAULT_RTP_PORT_BASE: u16 = 16000;
 pub const DEFAULT_RTP_PORT_TRIES: u16 = 200;
 /// Floor on the re-REGISTER interval (seconds) regardless of the server's expiry.
 const MIN_REREGISTER_SECS: u64 = 30;
+/// Consecutive REGISTER failures after which the refresh loop escalates its log
+/// from `warn` to `error`: by this point the trunk has been unreachable long
+/// enough that inbound calls are being lost, i.e. it is worth alerting on (the
+/// loop keeps retrying regardless; see [`SipAgent::is_registered`] to observe it).
+const REGISTER_ESCALATE_AFTER: u32 = 3;
+/// Time bound for best-effort teardown signaling — the BYE sent on a local hangup
+/// and the `Expires: 0` de-REGISTER on a graceful shutdown — so a dead peer or
+/// registrar can't pin the task for a full SIP transaction timeout (~32 s).
+const SIGNALING_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for a [`SipAgent`] (one trunk).
 #[derive(Debug, Clone)]
@@ -114,6 +129,10 @@ pub struct InboundInvite {
     offer: sdp::SdpMedia,
     /// The rsipstack server dialog to accept/reject.
     dialog: ServerInviteDialog,
+    /// The dialog layer this dialog lives in, so teardown (answer's supervisor or
+    /// `reject`) can remove it from the layer's map — otherwise every inbound call
+    /// permanently leaks a dialog there.
+    dialog_layer: Arc<DialogLayer>,
     /// IP we advertise in the SDP answer (public IP or local).
     advertise_ip: Ipv4Addr,
     /// RTP bind range (base, count) for the answer's media socket — carried from
@@ -146,7 +165,12 @@ impl InboundInvite {
             .map_err(|e| FlowcatError::Transport(format!("SIP accept failed: {e}")))?;
 
         let hangup = CancellationToken::new();
-        spawn_dialog_watch(self.state_rx, hangup.clone());
+        spawn_dialog_supervisor(
+            DialogHandle::Server(self.dialog),
+            self.dialog_layer,
+            self.state_rx,
+            hangup.clone(),
+        );
 
         Ok(SipTransport::start(
             rtp_sock,
@@ -159,9 +183,13 @@ impl InboundInvite {
 
     /// Reject this INVITE (default 486 Busy Here unless a code is given).
     pub fn reject(self, code: Option<rsip::StatusCode>) {
+        let id = self.dialog.id();
         let _ = self
             .dialog
             .reject(Some(code.unwrap_or(rsip::StatusCode::BusyHere)), None);
+        // The pump created this server dialog in the layer's map; drop it now so a
+        // rejected INVITE can't leak (no supervisor runs for a rejected call).
+        self.dialog_layer.remove_dialog(&id);
     }
 }
 
@@ -174,6 +202,15 @@ pub struct SipAgent {
     inbound_rx: Mutex<mpsc::Receiver<InboundInvite>>,
     /// IP advertised in SDP (public IP if configured, else the bound local addr).
     advertise_ip: Ipv4Addr,
+    /// Live registration state from the refresh loop: `true` while the trunk is
+    /// registered, `false` when de-registered or after a failed refresh. Initialized
+    /// `true` for a credential-less trunk (nothing to register). Read it via
+    /// [`SipAgent::is_registered`] / [`SipAgent::watch_registered`] for health checks.
+    registered: watch::Receiver<bool>,
+    /// Child cancel token for *just* the REGISTER refresh loop, so
+    /// [`SipAgent::unregister`] can stop the auto-refresh (and let an `Expires: 0`
+    /// land) without tearing down the still-needed endpoint.
+    register_cancel: CancellationToken,
     /// Root cancel token; dropping the agent (or calling [`SipAgent::shutdown`])
     /// tears down the endpoint + all background tasks.
     cancel: CancellationToken,
@@ -244,12 +281,20 @@ impl SipAgent {
             cancel.clone(),
         ));
 
+        // Registration state, observable for health checks. A credential-less
+        // trunk needs no REGISTER, so it starts (and stays) "registered".
+        let (registered_tx, registered_rx) = watch::channel(cfg.password.is_empty());
+        // The refresh loop gets its own child token so `unregister` can stop just
+        // the loop while the endpoint keeps running long enough to send Expires:0.
+        let register_cancel = cancel.child_token();
+
         // Registration loop (only if a password is configured).
         if !cfg.password.is_empty() {
             tokio::spawn(register_loop(
                 endpoint_inner.clone(),
                 cfg.clone(),
-                cancel.clone(),
+                register_cancel.clone(),
+                registered_tx,
             ));
         }
 
@@ -259,6 +304,8 @@ impl SipAgent {
             dialog_layer,
             inbound_rx: Mutex::new(inbound_rx),
             advertise_ip,
+            registered: registered_rx,
+            register_cancel,
             cancel,
         })
     }
@@ -288,6 +335,57 @@ impl SipAgent {
             )));
         }
         Ok(reg.expires())
+    }
+
+    /// Whether the trunk is currently registered (the last REGISTER refresh
+    /// succeeded). A credential-less trunk — which needs no registration — always
+    /// reports `true`. Use this for a liveness/health probe: a `false` here means
+    /// inbound calls will not arrive even though the agent is otherwise running.
+    pub fn is_registered(&self) -> bool {
+        *self.registered.borrow()
+    }
+
+    /// A [`watch::Receiver`] that yields each change to the registration state, so
+    /// an embedder can react to de-registration (alert, drain, fail a readiness
+    /// check) rather than poll [`SipAgent::is_registered`].
+    pub fn watch_registered(&self) -> watch::Receiver<bool> {
+        self.registered.clone()
+    }
+
+    /// Politely de-register the trunk (a REGISTER with `Expires: 0`) so the
+    /// registrar drops our binding immediately instead of holding it until the
+    /// granted expiry. Stops the auto-refresh loop first so it can't re-bind us,
+    /// then sends the de-REGISTER; call this before [`SipAgent::shutdown`] on a
+    /// graceful stop. Best-effort and time-bounded. A no-op without credentials.
+    pub async fn unregister(&self) -> Result<(), FlowcatError> {
+        // Stop the refresh loop first; otherwise it could REGISTER us straight back
+        // in right after the Expires:0 below. The endpoint stays up (root cancel
+        // untouched), so we can still send the de-REGISTER.
+        self.register_cancel.cancel();
+        if self.cfg.password.is_empty() {
+            return Ok(());
+        }
+        let credential = Credential {
+            username: self.cfg.login.clone(),
+            password: self.cfg.password.clone(),
+            realm: None,
+        };
+        let server = parse_server_uri(&self.cfg.server)?;
+        let mut reg = rsipstack::dialog::registration::Registration::new(
+            self.endpoint_inner.clone(),
+            Some(credential),
+        );
+        let resp = tokio::time::timeout(SIGNALING_TIMEOUT, reg.register(server, Some(0)))
+            .await
+            .map_err(|_| FlowcatError::Transport("de-REGISTER timed out".into()))?
+            .map_err(|e| FlowcatError::Transport(format!("de-REGISTER failed: {e}")))?;
+        if resp.status_code != rsip::StatusCode::OK {
+            return Err(FlowcatError::Transport(format!(
+                "de-REGISTER rejected: {}",
+                resp.status_code
+            )));
+        }
+        Ok(())
     }
 
     /// Yield the next inbound INVITE, or `None` once the agent is shut down.
@@ -355,7 +453,15 @@ impl SipAgent {
 
         let call_id = dialog.id().call_id.to_string();
         let hangup = CancellationToken::new();
-        spawn_dialog_watch(state_rx, hangup.clone());
+        // Retain the confirmed client dialog in the supervisor: it both lets us
+        // BYE the peer when the agent ends the call and removes the dialog from the
+        // layer's map on teardown (do_invite leaves the confirmed dialog there).
+        spawn_dialog_supervisor(
+            DialogHandle::Client(dialog),
+            self.dialog_layer.clone(),
+            state_rx,
+            hangup.clone(),
+        );
 
         Ok(SipTransport::start(
             rtp_sock,
@@ -378,19 +484,90 @@ impl Drop for SipAgent {
     }
 }
 
-/// Watch a dialog's state channel; on `Terminated` (BYE / timeout / decline)
-/// fire `hangup` so the [`SipTransport`] surfaces `MediaIn::Stop`.
-fn spawn_dialog_watch(mut state_rx: DialogStateReceiver, hangup: CancellationToken) {
+/// A confirmed INVITE dialog we own for the life of a call: it can be ended (we
+/// send a BYE) and must be removed from the dialog layer's map on teardown.
+/// Unifies the inbound (server) and outbound (client) dialog types so one
+/// supervisor handles both legs.
+enum DialogHandle {
+    /// Inbound call: we answered a remote INVITE.
+    Server(ServerInviteDialog),
+    /// Outbound call: we placed the INVITE.
+    Client(ClientInviteDialog),
+}
+
+impl DialogHandle {
+    /// The dialog's id — the key it is stored under in the [`DialogLayer`] map.
+    fn id(&self) -> DialogId {
+        match self {
+            DialogHandle::Server(d) => d.id(),
+            DialogHandle::Client(d) => d.id(),
+        }
+    }
+
+    /// Send a BYE to end the dialog (no-op/`Err` if it is already terminated).
+    async fn bye(&self) -> rsipstack::Result<()> {
+        match self {
+            DialogHandle::Server(d) => d.bye().await,
+            DialogHandle::Client(d) => d.bye().await,
+        }
+    }
+}
+
+/// Supervise one established dialog for the whole call, handling teardown from
+/// either direction and always releasing the dialog from the layer's map:
+///
+/// - **Peer-initiated** (BYE / timeout / decline): a `Terminated` dialog state
+///   fires `hangup`, so the [`SipTransport`] surfaces
+///   [`MediaIn::Stop`](crate::transport::MediaIn::Stop).
+/// - **Agent-initiated** (the `Call` ended, so the `SipTransport` was dropped,
+///   which cancels `hangup`): we send a BYE to the peer so the dialog doesn't
+///   dangle half-open on the carrier until it times out.
+///
+/// Either way we then [`remove_dialog`](DialogLayer::remove_dialog), so the dialog
+/// map can't grow without bound across calls (rsipstack leaves both answered
+/// server dialogs and confirmed client dialogs in the map otherwise).
+fn spawn_dialog_supervisor(
+    handle: DialogHandle,
+    dialog_layer: Arc<DialogLayer>,
+    mut state_rx: DialogStateReceiver,
+    hangup: CancellationToken,
+) {
     tokio::spawn(async move {
-        while let Some(state) = state_rx.recv().await {
-            if let DialogState::Terminated(id, reason) = state {
-                tracing::debug!(%id, ?reason, "SIP dialog terminated");
-                hangup.cancel();
-                break;
+        let id = handle.id();
+        loop {
+            tokio::select! {
+                // The local side ended the call (SipTransport dropped → hangup
+                // cancelled). Tell the peer with a BYE, time-bounded so a dead peer
+                // can't pin this task for the full SIP transaction timeout.
+                _ = hangup.cancelled() => {
+                    match tokio::time::timeout(SIGNALING_TIMEOUT, handle.bye()).await {
+                        Ok(Ok(())) => tracing::debug!(%id, "sent BYE on local hangup"),
+                        Ok(Err(e)) => {
+                            tracing::debug!(%id, error = %e, "BYE on local hangup failed (already terminated?)");
+                        }
+                        Err(_) => tracing::debug!(%id, "BYE on local hangup timed out"),
+                    }
+                    break;
+                }
+                // A dialog state transition from rsipstack.
+                state = state_rx.recv() => match state {
+                    // The peer (or a timeout) terminated the dialog.
+                    Some(DialogState::Terminated(tid, reason)) => {
+                        tracing::debug!(%tid, ?reason, "SIP dialog terminated by peer");
+                        hangup.cancel();
+                        break;
+                    }
+                    // Early / Confirmed / mid-call states: keep supervising.
+                    Some(_) => continue,
+                    // Channel closed without an explicit Terminated → treat as hangup.
+                    None => {
+                        hangup.cancel();
+                        break;
+                    }
+                },
             }
         }
-        // Channel closed without an explicit Terminated → also treat as hangup.
-        hangup.cancel();
+        dialog_layer.remove_dialog(&id);
     });
 }
 
@@ -494,6 +671,28 @@ async fn handle_new_invite(
         }
     };
 
+    // Reserve a slot on the inbound queue *before* creating any dialog. The pump
+    // is the single signaling task, so it must not block here: if the host's
+    // accept loop is saturated (queue full) or gone (closed), shed this call with
+    // 503 rather than awaiting capacity — awaiting would stall in-dialog BYE/ACK
+    // for calls already in progress behind us. Reserving first also means we never
+    // create a server dialog we then can't hand off (which would leak it).
+    //
+    // (A retransmitted INVITE does not reach here a second time: rsipstack's
+    // transaction layer matches the retransmit to the in-flight or just-finished
+    // server transaction and replays the response, so each INVITE surfaces as
+    // exactly one transaction — no per-Call-ID dedup is needed at this layer.)
+    let permit = match inbound_tx.try_reserve() {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::warn!(%call_id, "inbound queue full/closed; shedding INVITE with 503");
+            let _ = tx.reply(rsip::StatusCode::ServiceUnavailable).await;
+            return Err(FlowcatError::Transport(
+                "inbound queue full or closed".into(),
+            ));
+        }
+    };
+
     // Create the server dialog (allocates the To-tag) and its state channel.
     let (state_tx, state_rx): (DialogStateSender, DialogStateReceiver) =
         dialog_layer.new_dialog_state_channel();
@@ -514,22 +713,26 @@ async fn handle_new_invite(
         to_did,
         offer,
         dialog,
+        dialog_layer: dialog_layer.clone(),
         advertise_ip,
         rtp_port_base,
         rtp_port_tries,
         state_rx,
     };
-    inbound_tx
-        .send(invite)
-        .await
-        .map_err(|_| FlowcatError::Transport("inbound channel closed".into()))
+    permit.send(invite);
+    Ok(())
 }
 
-/// Background REGISTER + refresh loop (mirrors the rsipstack example).
+/// Background REGISTER + refresh loop. Keeps the trunk binding fresh, publishes
+/// the live registration state on `registered` (so the embedder can observe a
+/// trunk that has silently gone unreachable), and escalates its log from `warn`
+/// to `error` after [`REGISTER_ESCALATE_AFTER`] consecutive failures. It retries
+/// forever; cancellation (root shutdown or [`SipAgent::unregister`]) ends it.
 async fn register_loop(
     endpoint_inner: EndpointInnerRef,
     cfg: SipConfig,
     cancel: CancellationToken,
+    registered: watch::Sender<bool>,
 ) {
     let credential = Credential {
         username: cfg.login.clone(),
@@ -540,40 +743,69 @@ async fn register_loop(
         Ok(u) => u,
         Err(e) => {
             tracing::error!(error = %e, "SIP register loop: bad server URI; not registering");
+            let _ = registered.send(false);
             return;
         }
     };
     let mut reg =
         rsipstack::dialog::registration::Registration::new(endpoint_inner, Some(credential));
+    let mut consecutive_failures: u32 = 0;
     loop {
-        match reg.register(server.clone(), None).await {
+        let delay_secs = match reg.register(server.clone(), None).await {
             Ok(resp) if resp.status_code == rsip::StatusCode::OK => {
+                consecutive_failures = 0;
+                let _ = registered.send(true);
                 let expires = reg.expires();
                 tracing::info!(
                     expires = (expires as u64).max(MIN_REREGISTER_SECS),
                     "SIP registered"
                 );
-                tokio::select! {
-                    _ = cancel.cancelled() => return,
-                    _ = tokio::time::sleep(Duration::from_secs(reregister_delay_secs(expires))) => {}
-                }
+                reregister_delay_secs(expires)
             }
             Ok(resp) => {
-                tracing::warn!(status = %resp.status_code, "SIP register rejected; retrying");
-                tokio::select! {
-                    _ = cancel.cancelled() => return,
-                    _ = tokio::time::sleep(Duration::from_secs(MIN_REREGISTER_SECS)) => {}
-                }
+                consecutive_failures += 1;
+                let _ = registered.send(false);
+                log_register_failure(
+                    consecutive_failures,
+                    format_args!("rejected: {}", resp.status_code),
+                );
+                MIN_REREGISTER_SECS
             }
             Err(e) => {
-                tracing::warn!(error = %e, "SIP register error; retrying");
-                tokio::select! {
-                    _ = cancel.cancelled() => return,
-                    _ = tokio::time::sleep(Duration::from_secs(MIN_REREGISTER_SECS)) => {}
-                }
+                consecutive_failures += 1;
+                let _ = registered.send(false);
+                log_register_failure(consecutive_failures, format_args!("error: {e}"));
+                MIN_REREGISTER_SECS
             }
+        };
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = registered.send(false);
+                return;
+            }
+            _ = tokio::time::sleep(Duration::from_secs(delay_secs)) => {}
         }
     }
+}
+
+/// Log a REGISTER failure, escalating from `warn` to `error` once the trunk has
+/// failed [`REGISTER_ESCALATE_AFTER`] times in a row (by which point inbound calls
+/// are being lost and it is worth alerting on).
+fn log_register_failure(consecutive: u32, detail: std::fmt::Arguments<'_>) {
+    if register_failure_is_critical(consecutive) {
+        tracing::error!(
+            consecutive,
+            "SIP register {detail}; trunk is de-registered — inbound calls will not arrive"
+        );
+    } else {
+        tracing::warn!(consecutive, "SIP register {detail}; retrying");
+    }
+}
+
+/// Whether a run of `consecutive` REGISTER failures is severe enough to escalate
+/// the log to `error` (see [`REGISTER_ESCALATE_AFTER`]).
+fn register_failure_is_critical(consecutive: u32) -> bool {
+    consecutive >= REGISTER_ESCALATE_AFTER
 }
 
 // ---------------------------------------------------------------------------
@@ -750,6 +982,18 @@ mod tests {
     fn reregister_delay_scales_long_expiry_without_overflow() {
         assert_eq!(reregister_delay_secs(3600), 2700);
         assert_eq!(reregister_delay_secs(u32::MAX), (u32::MAX as u64) * 3 / 4);
+    }
+
+    // ── re-REGISTER failure escalation (#7: a silently de-registered trunk must
+    //    eventually log at `error`, not stay at `warn` forever) ─────────────────
+    #[test]
+    fn register_failure_escalates_only_at_threshold() {
+        assert!(!register_failure_is_critical(0));
+        assert!(!register_failure_is_critical(1));
+        assert!(!register_failure_is_critical(REGISTER_ESCALATE_AFTER - 1));
+        // At and beyond the threshold it is critical (escalated to `error`).
+        assert!(register_failure_is_critical(REGISTER_ESCALATE_AFTER));
+        assert!(register_failure_is_critical(REGISTER_ESCALATE_AFTER + 100));
     }
 
     /// Two RTP binds must get distinct ports (the scan steps past a taken port).

--- a/flowcat-core/src/sip/agent.rs
+++ b/flowcat-core/src/sip/agent.rs
@@ -472,14 +472,28 @@ impl SipAgent {
         ))
     }
 
-    /// Tear down the agent: cancels the endpoint serve loop + all tasks.
-    pub fn shutdown(&self) {
+    /// Gracefully tear down the agent: politely de-register the trunk
+    /// ([`SipAgent::unregister`] — best-effort and time-bounded) and then cancel
+    /// the endpoint serve loop + all background tasks.
+    ///
+    /// Prefer this over just dropping the agent: `Drop` is a hard stop that cancels
+    /// everything immediately and — being synchronous — cannot send the
+    /// `Expires: 0` de-REGISTER, so the registrar would hold a stale binding until
+    /// it expires. A de-REGISTER failure here is logged, not fatal; teardown
+    /// proceeds regardless.
+    pub async fn shutdown(&self) {
+        if let Err(e) = self.unregister().await {
+            tracing::warn!(error = %e, "SIP de-REGISTER on shutdown failed; tearing down anyway");
+        }
         self.cancel.cancel();
     }
 }
 
 impl Drop for SipAgent {
     fn drop(&mut self) {
+        // Hard stop / safety net: cancel the endpoint + all tasks. Drop is sync, so
+        // it cannot de-REGISTER — call `shutdown().await` for a graceful stop that
+        // releases the trunk binding first.
         self.cancel.cancel();
     }
 }
@@ -1035,5 +1049,177 @@ mod tests {
             "RTP port {p} is odd despite odd base (RFC 3550 wants even)"
         );
         drop(s);
+    }
+
+    // ── Loopback signaling integration: two in-process `SipAgent`s call each
+    //    other over 127.0.0.1, exercising the dialog lifecycle end to end (setup,
+    //    agent-initiated BYE, reject) and asserting dialogs don't leak from the
+    //    `DialogLayer` map. Like the `transport.rs` tests these open real loopback
+    //    UDP sockets, but they are fully hermetic: no registrar, no credentials,
+    //    no external host. ─────────────────────────────────────────────────────
+    use crate::transport::media::{MediaIn, MediaTransport};
+
+    /// Grab a currently-free UDP port on loopback. The probe socket is released
+    /// immediately and rebound by the agent — fine for an in-process test.
+    async fn free_udp_port() -> u16 {
+        let s = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let p = s.local_addr().unwrap().port();
+        drop(s);
+        p
+    }
+
+    /// Start a credential-less loopback agent on `sip_port`, advertising 127.0.0.1.
+    /// `server` is only consulted when the agent originates a call.
+    async fn start_loopback_agent(server: String, sip_port: u16) -> SipAgent {
+        let cfg = SipConfig {
+            server,
+            login: String::new(),
+            // Empty password → no REGISTER loop, so no registrar is needed.
+            password: String::new(),
+            caller_id: "1000".to_string(),
+            // Force the SDP/Contact/Via address to loopback so media + signaling
+            // both resolve to 127.0.0.1 regardless of the host's interfaces.
+            public_ip: Some(Ipv4Addr::LOCALHOST),
+            sip_port: Some(sip_port),
+            rtp_port_base: 40000,
+            rtp_port_tries: 200,
+        };
+        SipAgent::start(cfg).await.expect("agent start")
+    }
+
+    /// Poll `cond` every 20 ms for up to ~5 s; returns whether it became true.
+    async fn wait_until<F: Fn() -> bool>(cond: F) -> bool {
+        for _ in 0..250 {
+            if cond() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        cond()
+    }
+
+    /// Stand up a caller→callee pair on loopback. Returns both agents and both
+    /// media transports once the call is answered and confirmed.
+    async fn establish_loopback_call() -> (SipAgent, SipAgent, SipTransport, SipTransport) {
+        let port_b = free_udp_port().await;
+        let callee = start_loopback_agent("sip:127.0.0.1:1".to_string(), port_b).await;
+        let port_a = free_udp_port().await;
+        let caller = start_loopback_agent(format!("sip:127.0.0.1:{port_b}"), port_a).await;
+
+        // Answer on the callee side concurrently with the caller's originate.
+        let answer = tokio::spawn(async move {
+            let invite = tokio::time::timeout(Duration::from_secs(5), callee.next_inbound())
+                .await
+                .expect("inbound INVITE timed out")
+                .expect("callee shut down before INVITE");
+            // Identity comes from the SIP To user (the dialed number), not the body.
+            assert_eq!(invite.to_did, "2000");
+            let transport = invite.answer().await.expect("answer failed");
+            (callee, transport)
+        });
+
+        let caller_tr =
+            tokio::time::timeout(Duration::from_secs(5), caller.originate("2000", None))
+                .await
+                .expect("originate timed out")
+                .expect("outbound call not answered");
+        let (callee, callee_tr) = answer.await.expect("answer task panicked");
+        (caller, callee, caller_tr, callee_tr)
+    }
+
+    /// Drain `recv` past `StreamStart` and any (comfort-silence) audio until the
+    /// leg ends, asserting the terminal event is `Stop`.
+    async fn recv_until_stop(tr: &mut SipTransport) {
+        loop {
+            match tokio::time::timeout(Duration::from_secs(5), tr.recv())
+                .await
+                .expect("recv timed out waiting for Stop")
+            {
+                Some(MediaIn::StreamStart { .. }) | Some(MediaIn::Audio(_)) => continue,
+                other => {
+                    assert_eq!(other, Some(MediaIn::Stop), "expected Stop at end of leg");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// A full call sets up one dialog per leg; the agent ending the call (dropping
+    /// its transport) must BYE the peer (→ the peer's leg sees `Stop`) and both
+    /// dialogs must be removed from their layers (the leak fix, #1/#2/#3).
+    #[tokio::test]
+    async fn loopback_agent_hangup_byes_peer_and_removes_both_dialogs() {
+        let (caller, callee, caller_tr, mut callee_tr) = establish_loopback_call().await;
+
+        // Both legs established → exactly one dialog in each layer.
+        assert!(
+            wait_until(|| caller.dialog_layer.len() == 1).await,
+            "caller dialog missing after answer"
+        );
+        assert!(
+            wait_until(|| callee.dialog_layer.len() == 1).await,
+            "callee dialog missing after answer"
+        );
+
+        // Agent-initiated hangup: the caller ends the call by dropping its
+        // transport. Its supervisor must send a BYE to the callee.
+        drop(caller_tr);
+
+        // The callee's leg sees the BYE as end-of-media (Stop)…
+        recv_until_stop(&mut callee_tr).await;
+        // …and both dialogs are released from their layers (no leak).
+        assert!(
+            wait_until(|| caller.dialog_layer.is_empty()).await,
+            "caller dialog leaked after hangup"
+        );
+        assert!(
+            wait_until(|| callee.dialog_layer.is_empty()).await,
+            "callee dialog leaked after BYE"
+        );
+
+        caller.shutdown().await;
+        callee.shutdown().await;
+    }
+
+    /// Rejecting an inbound INVITE returns an error to the caller (no transport)
+    /// and removes the server dialog the pump created (the reject leak fix).
+    #[tokio::test]
+    async fn loopback_rejected_call_errors_and_removes_dialog() {
+        let port_b = free_udp_port().await;
+        let callee = start_loopback_agent("sip:127.0.0.1:1".to_string(), port_b).await;
+        let port_a = free_udp_port().await;
+        let caller = start_loopback_agent(format!("sip:127.0.0.1:{port_b}"), port_a).await;
+
+        let reject = tokio::spawn(async move {
+            let invite = tokio::time::timeout(Duration::from_secs(5), callee.next_inbound())
+                .await
+                .expect("inbound INVITE timed out")
+                .expect("callee shut down before INVITE");
+            invite.reject(None); // 486 Busy Here
+            callee
+        });
+
+        let res = tokio::time::timeout(Duration::from_secs(5), caller.originate("2000", None))
+            .await
+            .expect("originate timed out");
+        assert!(
+            res.is_err(),
+            "a rejected call must not yield a media transport"
+        );
+
+        let callee = reject.await.expect("reject task panicked");
+        // The rejected server dialog must be gone (no leak); the caller's
+        // unconfirmed client dialog is dropped by do_invite on the non-2xx too.
+        assert!(
+            wait_until(|| callee.dialog_layer.is_empty()).await,
+            "callee dialog leaked after reject"
+        );
+        assert!(
+            wait_until(|| caller.dialog_layer.is_empty()).await,
+            "caller dialog leaked after reject"
+        );
+
+        caller.shutdown().await;
+        callee.shutdown().await;
     }
 }

--- a/flowcat-server/Cargo.toml
+++ b/flowcat-server/Cargo.toml
@@ -27,6 +27,9 @@ server = [
     "flowcat-services/llm-all",
     "flowcat-services/realtime-all",
 ]
+# The browser WebRTC playground: the page, the SDP-offer endpoint over a str0m
+# transport, and the live-events WebSocket. Implies `server`.
+webrtc = ["server", "dep:flowcat-transports", "flowcat-transports/webrtc-str0m"]
 
 [dependencies]
 flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
@@ -37,6 +40,8 @@ flowcat-services = { path = "../flowcat-services", version = "0.1.0", default-fe
 flowcat-agent = { path = "../flowcat-agent", version = "0.1.0", optional = true }
 # Plivo answer XML (only needed by the server binary).
 flowcat-telephony = { path = "../flowcat-telephony", version = "0.1.0", optional = true }
+# str0m WebRTC transport (only needed by the `webrtc` playground feature).
+flowcat-transports = { path = "../flowcat-transports", version = "0.1.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/flowcat-server/Cargo.toml
+++ b/flowcat-server/Cargo.toml
@@ -9,17 +9,53 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = []
+# The HTTP server binary (axum) + the providers it can run. Pulls the runtime
+# deps and enables the full flowcat-services connector set so the binary can run
+# any provider named in the config. The default (no-feature) build is just the
+# library: the config schema + StaticSession + the run-orchestration helpers.
+server = [
+    "dep:axum",
+    "dep:tokio",
+    "dep:futures-util",
+    "dep:tracing-subscriber",
+    "dep:flowcat-agent",
+    "dep:flowcat-telephony",
+    "flowcat-services/stt-all",
+    "flowcat-services/tts-all",
+    "flowcat-services/llm-all",
+    "flowcat-services/realtime-all",
+]
+
 [dependencies]
 flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
-# `default-features = false` → only the provider-factory types (ProviderSpec); the
-# server's Cargo features (added with the binary) forward to flowcat-services.
+# `default-features = false` → only the provider-factory types in the library
+# build; the `server` feature turns on the full connector set.
 flowcat-services = { path = "../flowcat-services", version = "0.1.0", default-features = false }
+# The declarative `AgentBrain` (only needed by the server binary).
+flowcat-agent = { path = "../flowcat-agent", version = "0.1.0", optional = true }
+# Plivo answer XML (only needed by the server binary).
+flowcat-telephony = { path = "../flowcat-telephony", version = "0.1.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 async-trait = "0.1"
 tracing = "0.1"
 thiserror = "2"
+# Server-only runtime deps.
+axum = { version = "0.8", features = ["ws"], optional = true }
+tokio = { version = "1", features = ["full"], optional = true }
+futures-util = { version = "0.3", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+# `oneshot` the axum Router in offline server tests.
+tower = { version = "0.5", features = ["util"] }
+
+# The server binary builds only with `--features server`.
+[[bin]]
+name = "flowcat-server"
+path = "src/main.rs"
+required-features = ["server"]

--- a/flowcat-server/Cargo.toml
+++ b/flowcat-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "flowcat-server"
+description = "Config-driven single-agent server for the Flowcat voice runtime — run an agent from a YAML/JSON config with no control plane."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+flowcat-core = { path = "../flowcat-core", version = "0.1.0" }
+# `default-features = false` → only the provider-factory types (ProviderSpec); the
+# server's Cargo features (added with the binary) forward to flowcat-services.
+flowcat-services = { path = "../flowcat-services", version = "0.1.0", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+async-trait = "0.1"
+tracing = "0.1"
+thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/flowcat-server/src/config.rs
+++ b/flowcat-server/src/config.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! The agent/server config schema + loader.
+//!
+//! One [`ServerConfig`] describes a single-agent deployment: the agent graph, the
+//! pipeline [`TopologyConfig`] (realtime speech-to-speech or cascaded STT→LLM→TTS),
+//! the [`TransportConfig`], and the HTTP bind. Loaded from a YAML or JSON file.
+//!
+//! ```yaml
+//! agent:
+//!   graph: ./booking.json        # path to a graph_spec (or use `graph_inline`)
+//!   seed_vars: { brand: Acme }
+//! topology:
+//!   mode: realtime               # realtime | cascaded
+//!   provider: gemini
+//!   model: gemini-2.0-flash
+//!   # for cascaded:
+//!   # stt: { provider: deepgram, model: nova-3 }
+//!   # llm: { provider: openai,   model: gpt-4o }
+//!   # tts: { provider: cartesia, model: <voice-id> }
+//! transport: { kind: webrtc }    # webrtc | ws-plivo | sip | local
+//! server: { bind: "0.0.0.0:6210" }
+//! ```
+//!
+//! Provider **API keys are never in the file** — the host injects them into the
+//! resolved [`flowcat_services::ProviderSpec`] from its own env/secret store.
+
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use flowcat_services::ProviderSpec;
+
+/// One single-agent deployment.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    /// The agent: its graph + seed variables.
+    pub agent: AgentConfig,
+    /// The pipeline shape (realtime vs cascaded) + provider selections.
+    pub topology: TopologyConfig,
+    /// Where calls arrive from (default `webrtc`).
+    #[serde(default)]
+    pub transport: TransportConfig,
+    /// HTTP server settings.
+    #[serde(default)]
+    pub server: HttpConfig,
+}
+
+/// The agent definition: a graph spec (by path or inline) + seed variables.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentConfig {
+    /// Path to a `graph_spec` file (JSON or YAML), resolved relative to the config
+    /// file's directory. Mutually exclusive with [`AgentConfig::graph_inline`].
+    #[serde(default)]
+    pub graph: Option<String>,
+    /// An inline `graph_spec`. Takes precedence over [`AgentConfig::graph`].
+    #[serde(default)]
+    pub graph_inline: Option<Value>,
+    /// Variables seeded into the run (available to `{{var}}` interpolation).
+    #[serde(default)]
+    pub seed_vars: Map<String, Value>,
+}
+
+/// The pipeline shape + the provider selections for a call.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "mode", rename_all = "lowercase")]
+// Parsed once at startup; the size gap (Cascaded carries three ProviderSpecs) is
+// irrelevant here, so boxing for it isn't worth the ergonomic cost.
+#[allow(clippy::large_enum_variant)]
+pub enum TopologyConfig {
+    /// Realtime speech-to-speech (e.g. Gemini Live, OpenAI Realtime).
+    Realtime {
+        /// Realtime provider (default `gemini`).
+        #[serde(default = "default_realtime_provider")]
+        provider: String,
+        /// Model id (empty → the connector's default).
+        #[serde(default)]
+        model: String,
+        /// Provider-specific options (e.g. Vertex `project`/`location`, Azure `url`).
+        #[serde(default)]
+        options: Map<String, Value>,
+    },
+    /// Cascaded STT → LLM → TTS.
+    Cascaded {
+        /// Speech-to-text provider.
+        stt: ProviderSpec,
+        /// LLM provider.
+        llm: ProviderSpec,
+        /// Text-to-speech provider (`model` is the voice id).
+        tts: ProviderSpec,
+    },
+}
+
+fn default_realtime_provider() -> String {
+    "gemini".to_string()
+}
+
+/// The media transport calls arrive on.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TransportConfig {
+    /// `webrtc` | `ws-plivo` | `sip` | `local` (default `webrtc`).
+    #[serde(default = "default_transport_kind")]
+    pub kind: String,
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            kind: default_transport_kind(),
+        }
+    }
+}
+
+fn default_transport_kind() -> String {
+    "webrtc".to_string()
+}
+
+/// HTTP server settings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpConfig {
+    /// Bind address (default `0.0.0.0:6210`).
+    #[serde(default = "default_bind")]
+    pub bind: String,
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            bind: default_bind(),
+        }
+    }
+}
+
+fn default_bind() -> String {
+    "0.0.0.0:6210".to_string()
+}
+
+/// A config load/parse error.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// Failed to read a file (the config itself or a referenced graph).
+    #[error("read {path}: {source}")]
+    Read {
+        /// The path that failed to read.
+        path: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+    /// Failed to parse the config or graph document.
+    #[error("parse {path}: {msg}")]
+    Parse {
+        /// The path that failed to parse.
+        path: String,
+        /// The parser's message.
+        msg: String,
+    },
+    /// The agent graph is not specified or is invalid.
+    #[error("agent graph: {0}")]
+    Graph(String),
+}
+
+impl ServerConfig {
+    /// Load + parse a config file. `.yaml`/`.yml` → YAML, anything else → JSON.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+            path: path.display().to_string(),
+            source,
+        })?;
+        let is_yaml = matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("yaml") | Some("yml")
+        );
+        Self::parse(&text, is_yaml).map_err(|msg| ConfigError::Parse {
+            path: path.display().to_string(),
+            msg,
+        })
+    }
+
+    /// Parse config text (YAML when `is_yaml`, else JSON).
+    pub fn parse(text: &str, is_yaml: bool) -> Result<Self, String> {
+        if is_yaml {
+            serde_yaml::from_str(text).map_err(|e| e.to_string())
+        } else {
+            serde_json::from_str(text).map_err(|e| e.to_string())
+        }
+    }
+
+    /// Resolve the agent's `graph_spec` to a JSON value: `graph_inline` if present,
+    /// otherwise the `graph` file path read relative to `base_dir`.
+    pub fn resolve_graph(&self, base_dir: &Path) -> Result<Value, ConfigError> {
+        if let Some(inline) = &self.agent.graph_inline {
+            return Ok(inline.clone());
+        }
+        let rel = self.agent.graph.as_deref().ok_or_else(|| {
+            ConfigError::Graph("set `agent.graph` (a path) or `agent.graph_inline`".to_string())
+        })?;
+        let p = base_dir.join(rel);
+        let text = std::fs::read_to_string(&p).map_err(|source| ConfigError::Read {
+            path: p.display().to_string(),
+            source,
+        })?;
+        let is_yaml = matches!(
+            p.extension().and_then(|e| e.to_str()),
+            Some("yaml") | Some("yml")
+        );
+        if is_yaml {
+            serde_yaml::from_str(&text).map_err(|e| ConfigError::Graph(e.to_string()))
+        } else {
+            serde_json::from_str(&text).map_err(|e| ConfigError::Graph(e.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_realtime_yaml_with_defaults() {
+        let cfg = ServerConfig::parse(
+            r#"
+agent:
+  graph_inline: { nodes: [], edges: [] }
+  seed_vars: { brand: Acme }
+topology:
+  mode: realtime
+"#,
+            true,
+        )
+        .expect("valid realtime config");
+        match cfg.topology {
+            TopologyConfig::Realtime {
+                provider, model, ..
+            } => {
+                assert_eq!(provider, "gemini", "realtime provider defaults to gemini");
+                assert!(model.is_empty());
+            }
+            _ => panic!("expected realtime"),
+        }
+        // transport + server fall back to defaults.
+        assert_eq!(cfg.transport.kind, "webrtc");
+        assert_eq!(cfg.server.bind, "0.0.0.0:6210");
+        assert_eq!(cfg.agent.seed_vars.get("brand").unwrap(), "Acme");
+    }
+
+    #[test]
+    fn parses_cascaded_yaml_provider_specs() {
+        let cfg = ServerConfig::parse(
+            r#"
+agent: { graph: ./booking.json }
+topology:
+  mode: cascaded
+  stt: { provider: deepgram, model: nova-3 }
+  llm: { provider: openai, model: gpt-4o }
+  tts: { provider: cartesia, model: voice-xyz }
+transport: { kind: ws-plivo }
+server: { bind: "127.0.0.1:7000" }
+"#,
+            true,
+        )
+        .expect("valid cascaded config");
+        match cfg.topology {
+            TopologyConfig::Cascaded { stt, llm, tts } => {
+                assert_eq!(stt.provider, "deepgram");
+                assert_eq!(stt.model, "nova-3");
+                assert_eq!(llm.provider, "openai");
+                assert_eq!(llm.model, "gpt-4o");
+                assert_eq!(tts.provider, "cartesia");
+                assert_eq!(tts.model, "voice-xyz");
+                // keys are never in the file.
+                assert!(stt.api_key.is_empty() && llm.api_key.is_empty() && tts.api_key.is_empty());
+            }
+            _ => panic!("expected cascaded"),
+        }
+        assert_eq!(cfg.transport.kind, "ws-plivo");
+        assert_eq!(cfg.server.bind, "127.0.0.1:7000");
+    }
+
+    #[test]
+    fn parses_json_too() {
+        let cfg = ServerConfig::parse(
+            r#"{ "agent": { "graph_inline": {"nodes":[],"edges":[]} },
+                 "topology": { "mode": "realtime", "provider": "openai" } }"#,
+            false,
+        )
+        .expect("valid JSON config");
+        match cfg.topology {
+            TopologyConfig::Realtime { provider, .. } => assert_eq!(provider, "openai"),
+            _ => panic!("expected realtime"),
+        }
+    }
+
+    #[test]
+    fn resolve_graph_prefers_inline() {
+        let cfg = ServerConfig::parse(
+            r#"{ "agent": { "graph_inline": {"nodes":[{"id":"s"}],"edges":[]} },
+                 "topology": { "mode": "realtime" } }"#,
+            false,
+        )
+        .unwrap();
+        let g = cfg
+            .resolve_graph(Path::new("."))
+            .expect("inline graph resolves");
+        assert_eq!(g["nodes"][0]["id"], "s");
+    }
+
+    #[test]
+    fn resolve_graph_errors_when_neither_source_set() {
+        let cfg = ServerConfig::parse(
+            r#"{ "agent": {}, "topology": { "mode": "realtime" } }"#,
+            false,
+        )
+        .unwrap();
+        let err = cfg.resolve_graph(Path::new(".")).unwrap_err();
+        assert!(matches!(err, ConfigError::Graph(_)));
+    }
+}

--- a/flowcat-server/src/events.rs
+++ b/flowcat-server/src/events.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Per-call **live-event** bridge (RTVI → browser `rtf-*` frames).
+//!
+//! flowcat-core's [`RtviObserver`](flowcat_core::observer::RtviObserver) maps
+//! pipeline frames → RTVI messages and hands each to an `RtviSink`. [`RtfSink`] is
+//! that sink: it remaps each RTVI message to a browser `{type, payload}` `rtf-*`
+//! frame and pushes it onto a per-call channel keyed by a `pc_id`. The
+//! [`events_ws`] endpoint streams that channel to the browser so the playground can
+//! render the live transcript + tool-call + node-transition markers.
+//!
+//! The channel is an **unbounded mpsc** whose receiver exists from
+//! [`EventRegistry::register`] (called BEFORE the SDP answer is returned), so events
+//! published before the browser subscribes are **buffered, not lost**.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tracing::debug;
+
+use flowcat_core::observer::{RtviMessage, RtviSink};
+
+use crate::server::AppState;
+
+/// One call's event channel: the single consumer `rx` (taken once by [`events_ws`]).
+struct CallChannel {
+    rx: Mutex<Option<mpsc::UnboundedReceiver<String>>>,
+}
+
+/// Per-call live-event channels keyed by `pc_id`. Held in `AppState`.
+#[derive(Default)]
+pub struct EventRegistry {
+    calls: Mutex<HashMap<String, Arc<CallChannel>>>,
+}
+
+impl EventRegistry {
+    /// A fresh, empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a fresh channel for `pc_id`; returns the publish handle + a
+    /// drop-guard that deregisters on call end. Call BEFORE replying with the SDP
+    /// answer so no opening event is lost to a subscribe race.
+    pub fn register(self: &Arc<Self>, pc_id: &str) -> (CallEvents, RegistryGuard) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let ch = Arc::new(CallChannel {
+            rx: Mutex::new(Some(rx)),
+        });
+        self.calls.lock().unwrap().insert(pc_id.to_string(), ch);
+        (
+            CallEvents { tx },
+            RegistryGuard {
+                registry: Arc::clone(self),
+                pc_id: pc_id.to_string(),
+            },
+        )
+    }
+
+    /// Take the single consumer receiver for `pc_id` (once). `None` if no such call
+    /// or it was already taken.
+    fn take_receiver(&self, pc_id: &str) -> Option<mpsc::UnboundedReceiver<String>> {
+        let calls = self.calls.lock().unwrap();
+        let taken = calls.get(pc_id)?.rx.lock().unwrap().take();
+        taken
+    }
+
+    fn deregister(&self, pc_id: &str) {
+        self.calls.lock().unwrap().remove(pc_id);
+    }
+}
+
+/// Drop-guard: removes a call's channel from the registry when the call ends.
+pub struct RegistryGuard {
+    registry: Arc<EventRegistry>,
+    pc_id: String,
+}
+impl Drop for RegistryGuard {
+    fn drop(&mut self) {
+        self.registry.deregister(&self.pc_id);
+    }
+}
+
+/// Publish handle for one call's live-event channel. Fire-and-forget: a send with
+/// no live consumer is buffered (unbounded mpsc) or ignored once the call has ended.
+#[derive(Clone)]
+pub struct CallEvents {
+    tx: mpsc::UnboundedSender<String>,
+}
+impl CallEvents {
+    /// Publish a browser `{type, payload}` `rtf-*` frame.
+    pub fn publish(&self, type_: &str, payload: Value) {
+        let _ = self
+            .tx
+            .send(json!({ "type": type_, "payload": payload }).to_string());
+    }
+}
+
+/// flowcat `RtviSink` impl: turns each RTVI message into a browser `rtf-*` frame on
+/// the call channel. `send` is synchronous (the observer calls it inline) — the
+/// underlying mpsc send never blocks.
+pub struct RtfSink {
+    events: CallEvents,
+}
+impl RtfSink {
+    /// Wrap a call's publish handle as an `RtviSink`.
+    pub fn new(events: CallEvents) -> Self {
+        Self { events }
+    }
+}
+impl RtviSink for RtfSink {
+    fn send(&self, message: RtviMessage) {
+        if let Some((ty, payload)) = map_rtvi_to_rtf(&message) {
+            self.events.publish(ty, payload);
+        }
+    }
+}
+
+/// Map an RTVI message → the browser `rtf-*` `{type, payload}` the playground
+/// renders. Only the known set is forwarded; everything else is dropped. `data` is
+/// passed through (the UI reads the fields it needs and ignores extras).
+///
+/// `rtf-bot-text` comes from EXACTLY ONE kind — `bot-transcription` — so the
+/// realtime and cascaded paths each produce it once, with no doubling from
+/// `bot-tts-text`/`bot-output` (deliberately unmapped).
+fn map_rtvi_to_rtf(m: &RtviMessage) -> Option<(&'static str, Value)> {
+    let payload = m.data.clone().unwrap_or_else(|| json!({}));
+    let ty = match m.kind {
+        "user-transcription" => "rtf-user-transcription", // {text, final}
+        "bot-transcription" => "rtf-bot-text",            // {text}
+        "bot-started-speaking" => "rtf-bot-started-speaking",
+        "bot-stopped-speaking" => "rtf-bot-stopped-speaking",
+        "user-mute-started" => "rtf-user-mute-started",
+        "user-mute-stopped" => "rtf-user-mute-stopped",
+        "llm-function-call-started" | "llm-function-call-in-progress" => "rtf-function-call-start",
+        "llm-function-call-stopped" => "rtf-function-call-end",
+        _ => return None,
+    };
+    Some((ty, payload))
+}
+
+/// `GET /webrtc/events/{pc_id}` — stream a call's `rtf-*` frames to the browser.
+/// Serves only a registered `pc_id` (unknown → 404).
+pub async fn events_ws(
+    State(state): State<AppState>,
+    Path(pc_id): Path<String>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let Some(rx) = state.events.take_receiver(&pc_id) else {
+        return (StatusCode::NOT_FOUND, "no such call").into_response();
+    };
+    debug!(pc_id = %pc_id, "live events subscribed");
+    ws.on_upgrade(move |socket| stream_events(socket, rx))
+}
+
+async fn stream_events(mut socket: WebSocket, mut rx: mpsc::UnboundedReceiver<String>) {
+    while let Some(frame) = rx.recv().await {
+        if socket.send(Message::Text(frame.into())).await.is_err() {
+            break; // subscriber gone
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(kind: &'static str, data: Option<Value>) -> RtviMessage {
+        RtviMessage {
+            label: flowcat_core::observer::RTVI_MESSAGE_LABEL,
+            kind,
+            data,
+        }
+    }
+
+    #[test]
+    fn registry_register_subscribe_publish_and_drop() {
+        let reg = Arc::new(EventRegistry::new());
+        let (events, guard) = reg.register("pc-1");
+        let mut rx = reg.take_receiver("pc-1").expect("receiver");
+        // Single consumer: taking again yields None.
+        assert!(reg.take_receiver("pc-1").is_none());
+        // Publish reaches the consumer.
+        events.publish(
+            "rtf-user-transcription",
+            json!({ "text": "hi", "final": true }),
+        );
+        let got = rx.try_recv().expect("a frame");
+        assert!(got.contains("rtf-user-transcription") && got.contains("\"final\":true"));
+        // Drop the guard → the call is deregistered.
+        drop(guard);
+        assert!(reg.take_receiver("pc-1").is_none());
+    }
+
+    #[test]
+    fn map_rtvi_to_rtf_matches_the_browser_contract() {
+        assert_eq!(
+            map_rtvi_to_rtf(&msg(
+                "user-transcription",
+                Some(json!({"text":"hi","final":true}))
+            ))
+            .unwrap()
+            .0,
+            "rtf-user-transcription"
+        );
+        assert_eq!(
+            map_rtvi_to_rtf(&msg("bot-transcription", Some(json!({"text":"hello"}))))
+                .unwrap()
+                .0,
+            "rtf-bot-text"
+        );
+        assert_eq!(
+            map_rtvi_to_rtf(&msg(
+                "llm-function-call-in-progress",
+                Some(json!({"tool_call_id":"t1"}))
+            ))
+            .unwrap()
+            .0,
+            "rtf-function-call-start"
+        );
+        assert_eq!(
+            map_rtvi_to_rtf(&msg(
+                "llm-function-call-stopped",
+                Some(json!({"tool_call_id":"t1"}))
+            ))
+            .unwrap()
+            .0,
+            "rtf-function-call-end"
+        );
+        // Unmapped kinds are dropped (no double bot bubble, no noise).
+        assert!(map_rtvi_to_rtf(&msg("bot-tts-text", Some(json!({"text":"x"})))).is_none());
+        assert!(map_rtvi_to_rtf(&msg("metrics", None)).is_none());
+    }
+}

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! # flowcat-server
+//!
+//! A config-driven single-agent server for the Flowcat runtime: point it at a
+//! YAML/JSON config describing one agent (graph + topology + transport) and run
+//! that agent with **no control plane**.
+//!
+//! This crate exposes the building blocks the server wires together:
+//! - [`config`] — the agent/server config schema + loader ([`ServerConfig`]).
+//! - [`session`] — a control-plane-free [`session::StaticSession`] that satisfies
+//!   `flowcat_core::SessionSource` from the local config (resolve returns the
+//!   configured agent; artifacts are written to a local directory).
+//!
+//! The server binary + transport wiring (media WebSocket / WebRTC / SIP) build on
+//! these and land in a later change.
+
+pub mod config;
+pub mod session;
+
+pub use config::{ConfigError, ServerConfig, TopologyConfig};
+pub use session::StaticSession;

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -25,5 +25,10 @@ pub mod server;
 #[cfg(feature = "server")]
 pub mod socket;
 
+#[cfg(feature = "webrtc")]
+pub mod events;
+#[cfg(feature = "webrtc")]
+pub mod webrtc;
+
 pub use config::{ConfigError, ServerConfig, TopologyConfig};
 pub use session::StaticSession;

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -6,17 +6,24 @@
 //! YAML/JSON config describing one agent (graph + topology + transport) and run
 //! that agent with **no control plane**.
 //!
-//! This crate exposes the building blocks the server wires together:
 //! - [`config`] — the agent/server config schema + loader ([`ServerConfig`]).
-//! - [`session`] — a control-plane-free [`session::StaticSession`] that satisfies
-//!   `flowcat_core::SessionSource` from the local config (resolve returns the
-//!   configured agent; artifacts are written to a local directory).
+//! - [`session`] — a control-plane-free [`session::StaticSession`].
+//! - [`run`] — assemble + run the flowcat pipeline for one call from the config
+//!   topology (realtime or cascaded), resolving provider keys from the env.
 //!
-//! The server binary + transport wiring (media WebSocket / WebRTC / SIP) build on
-//! these and land in a later change.
+//! With the `server` Cargo feature, the crate also builds the **binary**: an axum
+//! HTTP server (health, the Plivo media WebSocket, the Plivo answer XML) that runs
+//! the configured agent. The default (no-feature) build is library-only and pulls
+//! no axum/tokio.
 
 pub mod config;
+pub mod run;
 pub mod session;
+
+#[cfg(feature = "server")]
+pub mod server;
+#[cfg(feature = "server")]
+pub mod socket;
 
 pub use config::{ConfigError, ServerConfig, TopologyConfig};
 pub use session::StaticSession;

--- a/flowcat-server/src/main.rs
+++ b/flowcat-server/src/main.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! `flowcat-server` binary: load an agent config and serve it over HTTP.
+//!
+//! ```text
+//! flowcat-server --config agent.yaml      # or a positional path, or $FLOWCAT_CONFIG
+//! ```
+//!
+//! Resolves the agent graph from the config, then runs an axum server exposing
+//! `/healthz`, `/readyz`, the Plivo media WebSocket, and the Plivo answer XML.
+//! Provider keys are read from the environment (see [`flowcat_server::run`]).
+
+use std::path::PathBuf;
+
+use flowcat_server::config::ServerConfig;
+use flowcat_server::server::{build_router, AppState};
+use tracing::info;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let config_path = config_path_from_args();
+    let config = match ServerConfig::load(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "flowcat-server: failed to load config {}: {e}",
+                config_path.display()
+            );
+            std::process::exit(1);
+        }
+    };
+    let base_dir = config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let graph = match config.resolve_graph(&base_dir) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("flowcat-server: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let bind = config.server.bind.clone();
+    let public_url = std::env::var("FLOWCAT_PUBLIC_URL").ok();
+    let app = build_router(AppState::new(config, graph, public_url));
+
+    let listener = match tokio::net::TcpListener::bind(&bind).await {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("flowcat-server: cannot bind {bind}: {e}");
+            std::process::exit(1);
+        }
+    };
+    info!(%bind, "flowcat-server listening");
+    if let Err(e) = axum::serve(listener, app).await {
+        eprintln!("flowcat-server: server error: {e}");
+        std::process::exit(1);
+    }
+}
+
+/// Resolve the config path: `--config <p>` / `-c <p>`, else the first positional
+/// arg, else `$FLOWCAT_CONFIG`, else `agent.yaml`.
+fn config_path_from_args() -> PathBuf {
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--config" | "-c" => {
+                if let Some(p) = args.next() {
+                    return PathBuf::from(p);
+                }
+            }
+            other if !other.starts_with('-') => return PathBuf::from(other),
+            _ => {}
+        }
+    }
+    std::env::var("FLOWCAT_CONFIG")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("agent.yaml"))
+}

--- a/flowcat-server/src/playground.html
+++ b/flowcat-server/src/playground.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Flowcat Playground</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+      h1 { font-size: 1.4rem; }
+      button { font-size: 1rem; padding: 0.5rem 1.1rem; border-radius: 8px; border: 1px solid #888; cursor: pointer; }
+      button[disabled] { opacity: 0.5; cursor: default; }
+      #status { margin: 0.75rem 0; font-size: 0.9rem; opacity: 0.8; }
+      #log { margin-top: 1rem; border: 1px solid #8884; border-radius: 8px; padding: 0.75rem; min-height: 12rem; }
+      .turn { margin: 0.35rem 0; line-height: 1.4; }
+      .user { color: #2563eb; }
+      .bot { color: #16a34a; }
+      .tool { color: #9333ea; font-style: italic; }
+      .meta { opacity: 0.6; font-size: 0.85rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Flowcat Playground</h1>
+    <p class="meta">Talk to the configured agent in your browser. Allow microphone access, then click Start.</p>
+    <button id="start">Start call</button>
+    <button id="stop" disabled>Hang up</button>
+    <p id="status">idle</p>
+    <div id="log"></div>
+
+    <script>
+      const startBtn = document.getElementById("start");
+      const stopBtn = document.getElementById("stop");
+      const statusEl = document.getElementById("status");
+      const logEl = document.getElementById("log");
+
+      let pc = null;
+      let micStream = null;
+      let eventsWs = null;
+      let userInterim = null; // the in-progress user transcript line
+
+      const setStatus = (s) => { statusEl.textContent = s; };
+
+      function line(cls, text) {
+        const div = document.createElement("div");
+        div.className = "turn " + cls;
+        div.textContent = text;
+        logEl.appendChild(div);
+        logEl.scrollTop = logEl.scrollHeight;
+        return div;
+      }
+
+      // Wait until ICE gathering finishes so the offer SDP carries candidates
+      // (the server replies with a single non-trickle answer).
+      function iceComplete(pc) {
+        if (pc.iceGatheringState === "complete") return Promise.resolve();
+        return new Promise((resolve) => {
+          const check = () => {
+            if (pc.iceGatheringState === "complete") {
+              pc.removeEventListener("icegatheringstatechange", check);
+              resolve();
+            }
+          };
+          pc.addEventListener("icegatheringstatechange", check);
+        });
+      }
+
+      function handleEvent(msg) {
+        const { type, payload } = msg;
+        const p = payload || {};
+        switch (type) {
+          case "rtf-user-transcription":
+            if (!userInterim) userInterim = line("user", "🧑 ");
+            userInterim.textContent = "🧑 " + (p.text || "");
+            if (p.final) userInterim = null;
+            break;
+          case "rtf-bot-text":
+            line("bot", "🤖 " + (p.text || ""));
+            break;
+          case "rtf-function-call-start":
+            line("tool", "🔧 " + (p.function_name || p.tool_name || "tool") + "(…)");
+            break;
+          case "rtf-function-call-end":
+            line("tool", "🔧 ↪ " + JSON.stringify(p.result ?? p));
+            break;
+          case "rtf-bot-started-speaking":
+            setStatus("agent speaking…");
+            break;
+          case "rtf-bot-stopped-speaking":
+            setStatus("listening…");
+            break;
+          default:
+            break; // ignore other rtf-* kinds
+        }
+      }
+
+      async function start() {
+        startBtn.disabled = true;
+        setStatus("requesting microphone…");
+        try {
+          micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (e) {
+          setStatus("microphone denied: " + e);
+          startBtn.disabled = false;
+          return;
+        }
+
+        pc = new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] });
+        micStream.getTracks().forEach((t) => pc.addTrack(t, micStream));
+
+        // Play the agent's audio.
+        pc.ontrack = (ev) => {
+          const audio = new Audio();
+          audio.autoplay = true;
+          audio.srcObject = ev.streams[0];
+        };
+        pc.onconnectionstatechange = () => {
+          if (["failed", "disconnected", "closed"].includes(pc.connectionState)) stop();
+        };
+
+        setStatus("negotiating…");
+        await pc.setLocalDescription(await pc.createOffer({ offerToReceiveAudio: true }));
+        await iceComplete(pc);
+
+        let resp;
+        try {
+          resp = await fetch("/webrtc/offer", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ sdp: pc.localDescription.sdp }),
+          });
+        } catch (e) {
+          setStatus("offer failed: " + e);
+          return stop();
+        }
+        if (!resp.ok) {
+          setStatus("offer rejected: " + resp.status + " " + (await resp.text()));
+          return stop();
+        }
+        const { sdp, pc_id } = await resp.json();
+        await pc.setRemoteDescription({ type: "answer", sdp });
+
+        // Subscribe to the live transcript.
+        const proto = location.protocol === "https:" ? "wss" : "ws";
+        eventsWs = new WebSocket(`${proto}://${location.host}/webrtc/events/${pc_id}`);
+        eventsWs.onmessage = (ev) => {
+          try { handleEvent(JSON.parse(ev.data)); } catch (_) {}
+        };
+
+        stopBtn.disabled = false;
+        setStatus("connected — listening…");
+      }
+
+      function stop() {
+        if (eventsWs) { try { eventsWs.close(); } catch (_) {} eventsWs = null; }
+        if (pc) { try { pc.close(); } catch (_) {} pc = null; }
+        if (micStream) { micStream.getTracks().forEach((t) => t.stop()); micStream = null; }
+        startBtn.disabled = false;
+        stopBtn.disabled = true;
+        setStatus("idle");
+      }
+
+      startBtn.addEventListener("click", start);
+      stopBtn.addEventListener("click", stop);
+    </script>
+  </body>
+</html>

--- a/flowcat-server/src/run.rs
+++ b/flowcat-server/src/run.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Call orchestration: assemble + run the flowcat pipeline for one call from the
+//! resolved [`TopologyConfig`].
+//!
+//! - **Realtime:** build the realtime backend via the provider factory and run
+//!   `build_s2s_task` (e.g. Gemini Live).
+//! - **Cascaded:** build STT/LLM/TTS via the factory and run `build_cascaded_call`.
+//!
+//! Provider **API keys are resolved from the environment** here (never from the
+//! config file or a per-call payload): `<PROVIDER>_API_KEY`, then
+//! `FLOWCAT_<PROVIDER>_API_KEY`, plus the well-known `GOOGLE_API_KEY` for the
+//! Gemini family.
+
+use std::sync::Arc;
+
+use serde_json::{Map, Value};
+
+use flowcat_core::observer::FrameObserver;
+use flowcat_core::pipeline::CascadedConfig;
+use flowcat_core::{AgentBrain, FlowcatError, MediaTransport, SessionSource};
+use flowcat_services::factory::{self, ProviderSpec};
+
+use crate::config::TopologyConfig;
+
+/// The ordered environment-variable names checked for `provider`'s API key.
+///
+/// Pure (no env access) so the precedence is unit-testable: the Gemini/Google
+/// family shares `GOOGLE_API_KEY`; then `<PROVIDER>_API_KEY` and
+/// `FLOWCAT_<PROVIDER>_API_KEY` (upper-cased, non-alphanumerics → `_`).
+pub fn key_env_var_names(provider: &str) -> Vec<String> {
+    let p = provider.to_ascii_lowercase();
+    let upper: String = p
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let mut names = Vec::new();
+    if matches!(p.as_str(), "gemini" | "google" | "google_realtime") {
+        names.push("GOOGLE_API_KEY".to_string());
+    }
+    names.push(format!("{upper}_API_KEY"));
+    names.push(format!("FLOWCAT_{upper}_API_KEY"));
+    names
+}
+
+/// Resolve a provider's API key from the environment (empty string if unset).
+pub fn key_from_env(provider: &str) -> String {
+    for name in key_env_var_names(provider) {
+        if let Ok(v) = std::env::var(&name) {
+            if !v.trim().is_empty() {
+                return v;
+            }
+        }
+    }
+    String::new()
+}
+
+/// Build a [`ProviderSpec`] from a provider name + model + options, injecting the
+/// API key from the environment.
+fn spec_with_env_key(provider: &str, model: &str, options: Map<String, Value>) -> ProviderSpec {
+    ProviderSpec {
+        provider: provider.to_string(),
+        model: model.to_string(),
+        api_key: key_from_env(provider),
+        options,
+    }
+}
+
+/// Fill a config [`ProviderSpec`]'s `api_key` from the environment if it's empty
+/// (the config file never carries keys).
+fn enrich(spec: &ProviderSpec) -> ProviderSpec {
+    let mut s = spec.clone();
+    if s.api_key.trim().is_empty() {
+        s.api_key = key_from_env(&s.provider);
+    }
+    s
+}
+
+/// Assemble + run one call over `transport` per the resolved [`TopologyConfig`].
+///
+/// The realtime/cascaded providers are built from the topology (keys from env);
+/// the pipeline runs to completion (returns when the call ends or errors).
+pub async fn run_call<T, B, S>(
+    transport: T,
+    topology: &TopologyConfig,
+    brain: B,
+    session: S,
+    run_id: i64,
+    token: String,
+    observers: Vec<Arc<dyn FrameObserver>>,
+) -> Result<(), FlowcatError>
+where
+    T: MediaTransport + 'static,
+    B: AgentBrain + 'static,
+    S: SessionSource + 'static,
+{
+    match topology {
+        TopologyConfig::Realtime {
+            provider,
+            model,
+            options,
+        } => {
+            let spec = spec_with_env_key(provider, model, options.clone());
+            let realtime = factory::realtime(&spec)?;
+            flowcat_core::pipeline::s2s::build_s2s_task_with_observers(
+                transport,
+                realtime,
+                brain,
+                session,
+                run_id,
+                token,
+                model.clone(),
+                observers,
+            )
+            .await?
+            .run()
+            .await
+        }
+        TopologyConfig::Cascaded { stt, llm, tts } => {
+            let (stt_svc, llm_svc, tts_svc) =
+                factory::cascaded(&enrich(stt), &enrich(llm), &enrich(tts))?;
+            let config = CascadedConfig {
+                system_prompt: Some(brain.system_prompt()),
+                ..Default::default()
+            };
+            flowcat_core::pipeline::build_cascaded_call_with_observers(
+                transport, stt_svc, llm_svc, tts_svc, brain, session, run_id, token, config,
+                observers,
+            )
+            .await?
+            .run()
+            .await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gemini_family_checks_google_api_key_first() {
+        let names = key_env_var_names("gemini");
+        assert_eq!(names[0], "GOOGLE_API_KEY");
+        assert!(names.contains(&"GEMINI_API_KEY".to_string()));
+        assert!(names.contains(&"FLOWCAT_GEMINI_API_KEY".to_string()));
+
+        // `google` and `google_realtime` share the alias too.
+        assert_eq!(key_env_var_names("google")[0], "GOOGLE_API_KEY");
+        assert_eq!(key_env_var_names("google_realtime")[0], "GOOGLE_API_KEY");
+    }
+
+    #[test]
+    fn provider_name_is_upper_snake_cased() {
+        let names = key_env_var_names("aws_bedrock");
+        assert_eq!(
+            names,
+            vec!["AWS_BEDROCK_API_KEY", "FLOWCAT_AWS_BEDROCK_API_KEY"]
+        );
+
+        // Hyphens / odd chars normalize to `_`.
+        assert_eq!(
+            key_env_var_names("nvidia-nim"),
+            vec!["NVIDIA_NIM_API_KEY", "FLOWCAT_NVIDIA_NIM_API_KEY"]
+        );
+    }
+
+    #[test]
+    fn non_gemini_provider_has_no_google_alias() {
+        let names = key_env_var_names("deepgram");
+        assert!(!names.iter().any(|n| n == "GOOGLE_API_KEY"));
+        assert_eq!(names[0], "DEEPGRAM_API_KEY");
+    }
+}

--- a/flowcat-server/src/server.rs
+++ b/flowcat-server/src/server.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! The axum HTTP server: health probes, the Plivo media WebSocket, and the Plivo
+//! answer XML. Single-agent and **unauthenticated** by design (it serves one
+//! configured agent with no control plane) — front it with your own ingress/auth
+//! for anything public.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State, WebSocketUpgrade};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tracing::{error, info, warn};
+
+use flowcat_agent::DeclarativeBrain;
+use flowcat_core::{PlivoSerializer, WsCarrierTransport};
+
+use crate::config::{ServerConfig, TopologyConfig};
+use crate::run;
+use crate::session::StaticSession;
+use crate::socket::AxumWsSocket;
+
+/// Telephony carrier μ-law @ 8 kHz (the Plivo WS media format).
+const CARRIER_RATE: u32 = 8_000;
+
+/// Shared handler state: the resolved config + the agent graph (resolved once at
+/// startup) + this host's public base URL (for the Plivo answer XML).
+#[derive(Clone)]
+pub struct AppState {
+    config: Arc<ServerConfig>,
+    graph: Arc<Value>,
+    public_url: Arc<Option<String>>,
+}
+
+impl AppState {
+    /// Build the shared state from a loaded config + its resolved graph spec.
+    pub fn new(config: ServerConfig, graph: Value, public_url: Option<String>) -> Self {
+        Self {
+            config: Arc::new(config),
+            graph: Arc::new(graph),
+            public_url: Arc::new(public_url),
+        }
+    }
+}
+
+/// Assemble the axum router over the shared [`AppState`].
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/telephony/ws/{provider}/{run_id}", get(media_ws))
+        .route("/telephony/answer/plivo/{run_id}", get(answer_plivo))
+        .with_state(state)
+}
+
+async fn healthz() -> impl IntoResponse {
+    axum::Json(json!({ "status": "ok" }))
+}
+
+async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
+    let ready = primary_provider_key_present(&state.config);
+    let code = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (code, axum::Json(json!({ "ready": ready })))
+}
+
+/// True iff the configured topology's primary provider has an API key in the env
+/// (realtime: the realtime provider; cascaded: the LLM leg).
+fn primary_provider_key_present(config: &ServerConfig) -> bool {
+    let provider = match &config.topology {
+        TopologyConfig::Realtime { provider, .. } => provider.as_str(),
+        TopologyConfig::Cascaded { llm, .. } => llm.provider.as_str(),
+    };
+    !run::key_from_env(provider).is_empty()
+}
+
+#[derive(Deserialize)]
+struct TokenQuery {
+    #[serde(default)]
+    token: String,
+}
+
+/// `GET /telephony/ws/{provider}/{run_id}?token=` — the bidirectional Plivo media
+/// WS. The brain is built before the upgrade so a bad graph is a clean 422.
+async fn media_ws(
+    State(state): State<AppState>,
+    Path((provider, run_id)): Path<(String, i64)>,
+    Query(q): Query<TokenQuery>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let provider = provider.to_ascii_lowercase();
+    if provider != "plivo" {
+        warn!(%provider, "media ws: only the 'plivo' carrier is served by this endpoint");
+        return (StatusCode::NOT_FOUND, "unsupported carrier (only 'plivo')").into_response();
+    }
+
+    let brain = match DeclarativeBrain::new(
+        state.graph.as_ref(),
+        Value::Object(Default::default()),
+        state.config.agent.seed_vars.clone(),
+    ) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "media ws: invalid agent graph");
+            return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
+        }
+    };
+
+    let token = q.token;
+    info!(run_id, "plivo media ws upgrading");
+    ws.on_upgrade(move |socket| async move {
+        let transport = WsCarrierTransport::new(
+            AxumWsSocket::new(socket),
+            PlivoSerializer::new(CARRIER_RATE),
+        );
+        let session = StaticSession::new(
+            (*state.graph).clone(),
+            state.config.agent.seed_vars.clone(),
+            "plivo",
+        );
+        let res = run::run_call(
+            transport,
+            &state.config.topology,
+            brain,
+            session,
+            run_id,
+            token,
+            vec![],
+        )
+        .await;
+        match res {
+            Ok(()) => info!(run_id, "plivo call ended cleanly"),
+            Err(e) => error!(run_id, error = %e, "plivo call ended with error"),
+        }
+    })
+}
+
+/// `GET /telephony/answer/plivo/{run_id}?token=` — the Plivo `<Stream>` answer XML
+/// pointing back at this host's media WS. Needs `FLOWCAT_PUBLIC_URL` to build a
+/// reachable `wss://` URL.
+async fn answer_plivo(
+    State(state): State<AppState>,
+    Path(run_id): Path<i64>,
+    Query(q): Query<TokenQuery>,
+) -> Response {
+    let Some(public_base) = state.public_url.as_deref().filter(|s| !s.is_empty()) else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "FLOWCAT_PUBLIC_URL not set — cannot build a reachable wss:// answer URL",
+        )
+            .into_response();
+    };
+    let xml = flowcat_telephony::plivo_answer_xml(run_id, &q.token, public_base);
+    ([(axum::http::header::CONTENT_TYPE, "text/xml")], xml).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt; // oneshot
+
+    fn test_state(public_url: Option<String>) -> AppState {
+        let config = ServerConfig::parse(
+            r#"{ "agent": { "graph_inline": {"nodes":[{"id":"s","type":"startCall"}],"edges":[]} },
+                 "topology": { "mode": "realtime", "provider": "gemini" } }"#,
+            false,
+        )
+        .unwrap();
+        let graph = config.resolve_graph(std::path::Path::new(".")).unwrap();
+        AppState::new(config, graph, public_url)
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_ok() {
+        let app = build_router(test_state(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn answer_plivo_needs_public_url() {
+        // No FLOWCAT_PUBLIC_URL configured → 503 with a clear message.
+        let app = build_router(test_state(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/telephony/answer/plivo/1?token=t")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn answer_plivo_emits_stream_xml_when_public_url_set() {
+        let app = build_router(test_state(Some("https://voice.example.com".to_string())));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/telephony/answer/plivo/42?token=tok")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let xml = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            xml.contains("wss://voice.example.com/telephony/ws/plivo/42?token=tok"),
+            "{xml}"
+        );
+    }
+
+    // The non-plivo carrier rejection inside `media_ws` runs *after* axum's
+    // `WebSocketUpgrade` extractor, so it can't be reached with a plain (non-WS)
+    // `oneshot` request — it would need a real WebSocket handshake. The provider
+    // check itself is a simple string compare; the WS handshake path is covered by
+    // an end-to-end call rather than a router unit test.
+}

--- a/flowcat-server/src/server.rs
+++ b/flowcat-server/src/server.rs
@@ -31,9 +31,19 @@ const CARRIER_RATE: u32 = 8_000;
 /// startup) + this host's public base URL (for the Plivo answer XML).
 #[derive(Clone)]
 pub struct AppState {
-    config: Arc<ServerConfig>,
-    graph: Arc<Value>,
-    public_url: Arc<Option<String>>,
+    pub(crate) config: Arc<ServerConfig>,
+    pub(crate) graph: Arc<Value>,
+    pub(crate) public_url: Arc<Option<String>>,
+    /// Per-call live-event channels for the WebRTC playground.
+    #[cfg(feature = "webrtc")]
+    pub(crate) events: Arc<crate::events::EventRegistry>,
+    /// Monotonic per-call id source (`pc-<n>`).
+    #[cfg(feature = "webrtc")]
+    pub(crate) next_pc: Arc<std::sync::atomic::AtomicU64>,
+    /// Concrete IPv4 the str0m media socket binds (str0m rejects 0.0.0.0); from
+    /// `FLOWCAT_WEBRTC_BIND_IP`, default loopback.
+    #[cfg(feature = "webrtc")]
+    pub(crate) webrtc_bind_ip: std::net::Ipv4Addr,
 }
 
 impl AppState {
@@ -43,18 +53,40 @@ impl AppState {
             config: Arc::new(config),
             graph: Arc::new(graph),
             public_url: Arc::new(public_url),
+            #[cfg(feature = "webrtc")]
+            events: Arc::new(crate::events::EventRegistry::new()),
+            #[cfg(feature = "webrtc")]
+            next_pc: Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            #[cfg(feature = "webrtc")]
+            webrtc_bind_ip: webrtc_bind_ip_from_env(),
         }
     }
 }
 
+/// Resolve the WebRTC media bind IP from `FLOWCAT_WEBRTC_BIND_IP` (default
+/// `127.0.0.1`; str0m advertises it as the host ICE candidate and rejects 0.0.0.0).
+#[cfg(feature = "webrtc")]
+fn webrtc_bind_ip_from_env() -> std::net::Ipv4Addr {
+    std::env::var("FLOWCAT_WEBRTC_BIND_IP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(std::net::Ipv4Addr::LOCALHOST)
+}
+
 /// Assemble the axum router over the shared [`AppState`].
 pub fn build_router(state: AppState) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/telephony/ws/{provider}/{run_id}", get(media_ws))
-        .route("/telephony/answer/plivo/{run_id}", get(answer_plivo))
-        .with_state(state)
+        .route("/telephony/answer/plivo/{run_id}", get(answer_plivo));
+    // The browser playground (page + WebRTC offer + live-events WS).
+    #[cfg(feature = "webrtc")]
+    let router = router
+        .route("/", get(crate::webrtc::playground_page))
+        .route("/webrtc/offer", axum::routing::post(crate::webrtc::offer))
+        .route("/webrtc/events/{pc_id}", get(crate::events::events_ws));
+    router.with_state(state)
 }
 
 async fn healthz() -> impl IntoResponse {

--- a/flowcat-server/src/session.rs
+++ b/flowcat-server/src/session.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! [`StaticSession`] — a control-plane-free [`SessionSource`].
+//!
+//! flowcat's runtime resolves each call through a `SessionSource` (fetch the
+//! agent config, upload recordings/transcripts, write the finalize). Embedders
+//! back that with their control-plane HTTP API — but there was no default, so you
+//! could not run a call without writing one. `StaticSession` fills that gap: it
+//! serves a single agent from a local config and writes artifacts to a local
+//! directory, so any flowcat user can run a real call with no control plane.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde_json::{json, Map, Value};
+use tracing::info;
+
+use flowcat_core::session::{Finalize, ResolvedCall, ToolDecl, UploadTarget};
+use flowcat_core::{FlowcatError, SessionSource};
+
+/// A [`SessionSource`] backed by a single in-memory agent config (no control
+/// plane). `resolve` always returns the configured agent; artifacts are written
+/// under a local directory; workflow-tool relay is a no-op (declarative graph
+/// transitions come from the brain, not the control plane).
+pub struct StaticSession {
+    /// `{ "graph_spec": …, "runtime_options": {}, "seed_vars": … }`.
+    brain_config: Value,
+    /// Provider label echoed back in the resolved call.
+    provider: String,
+    /// Directory artifacts (recording/transcript) are written to.
+    artifact_dir: PathBuf,
+}
+
+impl StaticSession {
+    /// Build from the agent's `graph_spec` + seed variables. `provider` is the
+    /// label echoed in [`ResolvedCall::provider`] (e.g. the transport kind).
+    pub fn new(
+        graph_spec: Value,
+        seed_vars: Map<String, Value>,
+        provider: impl Into<String>,
+    ) -> Self {
+        Self {
+            brain_config: json!({
+                "graph_spec": graph_spec,
+                "runtime_options": {},
+                "seed_vars": seed_vars,
+            }),
+            provider: provider.into(),
+            artifact_dir: PathBuf::from("flowcat-artifacts"),
+        }
+    }
+
+    /// Override where artifacts are written (default `./flowcat-artifacts`).
+    pub fn with_artifact_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.artifact_dir = dir.into();
+        self
+    }
+}
+
+#[async_trait]
+impl SessionSource for StaticSession {
+    async fn resolve(&self, _run_id: i64, _token: &str) -> Result<ResolvedCall, FlowcatError> {
+        Ok(ResolvedCall {
+            provider: self.provider.clone(),
+            brain_config: self.brain_config.clone(),
+            is_completed: false,
+        })
+    }
+
+    async fn complete(&self, run_id: i64, _token: &str, fin: Finalize) -> Result<(), FlowcatError> {
+        info!(
+            run_id,
+            usage = %fin.usage,
+            collected_vars = %fin.collected_vars,
+            recording = ?fin.recording_url,
+            transcript = ?fin.transcript_url,
+            "static session: run complete"
+        );
+        Ok(())
+    }
+
+    async fn artifact_upload_url(
+        &self,
+        run_id: i64,
+        _token: &str,
+        kind: &str,
+    ) -> Result<UploadTarget, FlowcatError> {
+        std::fs::create_dir_all(&self.artifact_dir)
+            .map_err(|e| FlowcatError::Session(format!("create artifact dir: {e}")))?;
+        let key = format!("run-{run_id}-{kind}");
+        let url = format!("file://{}", self.artifact_dir.join(&key).display());
+        let content_type = match kind {
+            "recording" => "audio/wav",
+            "transcript" => "application/json",
+            _ => "application/octet-stream",
+        }
+        .to_string();
+        Ok(UploadTarget {
+            url,
+            key,
+            content_type,
+        })
+    }
+
+    async fn put_bytes(
+        &self,
+        url: &str,
+        bytes: Vec<u8>,
+        _content_type: &str,
+    ) -> Result<(), FlowcatError> {
+        let path = url.strip_prefix("file://").ok_or_else(|| {
+            FlowcatError::Session(format!(
+                "static session only supports file:// upload targets, got {url:?}"
+            ))
+        })?;
+        std::fs::write(path, bytes)
+            .map_err(|e| FlowcatError::Session(format!("write artifact {path}: {e}")))?;
+        Ok(())
+    }
+
+    async fn node_tools(
+        &self,
+        _run_id: i64,
+        _token: &str,
+        _node_id: &str,
+    ) -> Result<Vec<ToolDecl>, FlowcatError> {
+        // No control-plane workflow tools in the static session; the declarative
+        // graph's transitions are supplied by the brain itself.
+        Ok(vec![])
+    }
+
+    async fn tool_call(
+        &self,
+        _run_id: i64,
+        _token: &str,
+        _node_id: &str,
+        tool_name: &str,
+        _args: &Value,
+    ) -> Result<String, FlowcatError> {
+        Ok(format!(
+            "tool {tool_name:?} is not available in the static/local session"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session() -> StaticSession {
+        StaticSession::new(
+            json!({ "nodes": [{ "id": "s", "type": "startCall" }], "edges": [] }),
+            Map::new(),
+            "local",
+        )
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_the_configured_agent() {
+        let r = session().resolve(1, "tok").await.unwrap();
+        assert_eq!(r.provider, "local");
+        assert!(!r.is_completed);
+        assert_eq!(r.brain_config["graph_spec"]["nodes"][0]["id"], "s");
+        assert!(r.brain_config["runtime_options"].is_object());
+    }
+
+    #[tokio::test]
+    async fn node_tools_are_empty_and_tool_call_is_a_noop_message() {
+        let s = session();
+        assert!(s.node_tools(1, "t", "s").await.unwrap().is_empty());
+        let msg = s
+            .tool_call(1, "t", "s", "lookup", &json!({}))
+            .await
+            .unwrap();
+        assert!(msg.contains("not available"), "got: {msg}");
+        assert!(msg.contains("lookup"));
+    }
+
+    #[tokio::test]
+    async fn artifact_round_trips_to_a_local_file() {
+        let dir = std::env::temp_dir().join("flowcat-server-session-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let s = session().with_artifact_dir(&dir);
+
+        let target = s.artifact_upload_url(7, "tok", "transcript").await.unwrap();
+        assert!(target.url.starts_with("file://"));
+        assert_eq!(target.key, "run-7-transcript");
+        assert_eq!(target.content_type, "application/json");
+
+        s.put_bytes(&target.url, b"hello".to_vec(), &target.content_type)
+            .await
+            .unwrap();
+        let written = std::fs::read(dir.join(&target.key)).unwrap();
+        assert_eq!(written, b"hello");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn put_bytes_rejects_non_file_urls() {
+        let err = session()
+            .put_bytes(
+                "https://example.com/x",
+                b"x".to_vec(),
+                "application/octet-stream",
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("file://"), "got: {err}");
+    }
+}

--- a/flowcat-server/src/socket.rs
+++ b/flowcat-server/src/socket.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! [`AxumWsSocket`] — a flowcat-core [`MediaSocket`] over an inbound axum WebSocket.
+//!
+//! flowcat-core's media path is generic over `T: MediaSocket`, so the cleanest
+//! server-side adapter is a direct impl over [`axum::extract::ws::WebSocket`] — no
+//! tungstenite round-trip (flowcat ships a client-side WS transport; for an
+//! inbound carrier WS we adapt the axum socket straight to the trait).
+//!
+//! ## Why the socket is split (read half here, write half in a writer task)
+//!
+//! The bidirectional carrier WS is shared (behind one async mutex) between the
+//! recv pump and the audio sender. If `recv` and `send` used the *same* socket, a
+//! `send` blocked on WS-write **backpressure** (the model's replies are bursty and
+//! can fill the write buffer faster than the carrier drains it) would hold the
+//! shared lock and **starve the recv pump** — caller audio would stop reaching the
+//! model and the realtime session would idle-abort. So we `split()` the socket:
+//! `recv` reads the **stream** half, and `send_*` is a **non-blocking enqueue** to a
+//! dedicated writer task that owns the **sink** half and absorbs backpressure off
+//! the shared lock.
+
+use async_trait::async_trait;
+use axum::extract::ws::{Message, WebSocket};
+use futures_util::stream::SplitStream;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+
+use flowcat_core::{FlowcatError, MediaSocket, WsIn};
+
+/// Wraps an accepted axum [`WebSocket`] as a flowcat-core [`MediaSocket`], with the
+/// write half driven by a separate task so sends never block reads.
+pub struct AxumWsSocket {
+    /// Read half — `recv` reads carrier frames here.
+    rx: SplitStream<WebSocket>,
+    /// Outbound queue drained by the writer task (owns the sink half). Unbounded so
+    /// `send_*` is a synchronous enqueue that can't block the shared lock; the
+    /// writer task is where real WS-write backpressure is absorbed.
+    tx: mpsc::UnboundedSender<Message>,
+}
+
+impl AxumWsSocket {
+    /// Adapt an already-`accept`-ed axum WebSocket. Spawns the writer task that
+    /// drains queued outbound frames into the split sink (requires a Tokio runtime
+    /// — always true on the media-WS request path).
+    pub fn new(ws: WebSocket) -> Self {
+        let (mut sink, rx) = ws.split();
+        let (tx, mut out_rx) = mpsc::unbounded_channel::<Message>();
+        tokio::spawn(async move {
+            // Drain queued frames to the carrier; WS-write backpressure is absorbed
+            // here (NOT under the recv/send shared lock). Exits when the queue is
+            // closed (socket dropped on call end) or the carrier write fails.
+            while let Some(msg) = out_rx.recv().await {
+                if sink.send(msg).await.is_err() {
+                    break;
+                }
+            }
+            let _ = sink.close().await;
+        });
+        Self { rx, tx }
+    }
+}
+
+#[async_trait]
+impl MediaSocket for AxumWsSocket {
+    async fn recv(&mut self) -> Option<WsIn> {
+        // Loop so keepalive frames (Ping/Pong) never surface as actionable media:
+        // keep reading until a Text/Binary/Close, a stream error, or end-of-stream.
+        loop {
+            match self.rx.next().await {
+                Some(Ok(Message::Text(t))) => return Some(WsIn::Text(t.as_str().to_owned())),
+                Some(Ok(Message::Binary(b))) => return Some(WsIn::Binary(b.to_vec())),
+                Some(Ok(Message::Close(_))) => return Some(WsIn::Close),
+                // Carriers send pings to keep the socket warm — not media.
+                Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => continue,
+                // A transport error is terminal for the call: treat it like a peer
+                // close so the pipeline tears down + finalizes cleanly.
+                Some(Err(_)) => return Some(WsIn::Close),
+                None => return None,
+            }
+        }
+    }
+
+    async fn send_text(&mut self, s: String) -> Result<(), FlowcatError> {
+        // Non-blocking enqueue; the writer task performs the actual WS write.
+        self.tx
+            .send(Message::text(s))
+            .map_err(|_| FlowcatError::Transport("axum ws send_text: writer task closed".into()))
+    }
+
+    async fn send_binary(&mut self, b: Vec<u8>) -> Result<(), FlowcatError> {
+        self.tx
+            .send(Message::binary(b))
+            .map_err(|_| FlowcatError::Transport("axum ws send_binary: writer task closed".into()))
+    }
+}

--- a/flowcat-server/src/webrtc.rs
+++ b/flowcat-server/src/webrtc.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Browser WebRTC playground: `GET /` serves the page, `POST /webrtc/offer`
+//! accepts a browser SDP offer and runs the configured agent over a str0m
+//! [`WebRtcTransport`], and the live transcript streams over
+//! `/webrtc/events/{pc_id}` (see [`crate::events`]).
+//!
+//! This is the "talk to your agent in the browser" path: no control plane, no
+//! credentials in the page — the server runs the single configured agent and the
+//! browser is just a mic + speaker + transcript view.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{error, info, warn};
+
+use flowcat_agent::DeclarativeBrain;
+use flowcat_core::observer::{FrameObserver, RtviObserver, RtviSink};
+use flowcat_transports::WebRtcTransport;
+
+use crate::events::RtfSink;
+use crate::run;
+use crate::server::AppState;
+use crate::session::StaticSession;
+
+/// str0m carrier rate — matches the realtime input rate (the S2S processors
+/// resample to 16 kHz in / 24 kHz out internally).
+const WEBRTC_CARRIER_RATE: u32 = 16_000;
+
+/// The static playground page (vanilla JS: mic → WebRTC offer → audio out + a live
+/// transcript over the events WS). Embedded so the binary is self-contained.
+const PLAYGROUND_HTML: &str = include_str!("playground.html");
+
+/// Browser SDP offer.
+#[derive(Debug, Deserialize)]
+pub struct OfferRequest {
+    /// The browser's SDP offer (post-ICE-gathering, so it carries candidates).
+    pub sdp: String,
+}
+
+/// SDP answer + the per-call id the browser uses to subscribe to live events.
+#[derive(Debug, Serialize)]
+pub struct OfferResponse {
+    /// The str0m SDP answer.
+    pub sdp: String,
+    /// Per-call id (`pc-<n>`); the browser opens `/webrtc/events/{pc_id}`.
+    pub pc_id: String,
+}
+
+/// `GET /` — the browser playground page.
+pub async fn playground_page() -> Html<&'static str> {
+    Html(PLAYGROUND_HTML)
+}
+
+/// `POST /webrtc/offer` — accept the browser SDP offer and run the configured agent.
+pub async fn offer(State(state): State<AppState>, Json(body): Json<OfferRequest>) -> Response {
+    // Build the brain from the configured graph BEFORE accepting the offer, so a
+    // bad graph is a clean 422 with no peer created.
+    let brain = match DeclarativeBrain::new(
+        state.graph.as_ref(),
+        Value::Object(Default::default()),
+        state.config.agent.seed_vars.clone(),
+    ) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "webrtc offer: invalid agent graph");
+            return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
+        }
+    };
+
+    // Bind a UDP socket for the WebRTC media on the configured interface (str0m
+    // advertises this as the host ICE candidate and rejects 0.0.0.0).
+    let bind = SocketAddr::new(IpAddr::V4(state.webrtc_bind_ip), 0);
+    let socket = match tokio::net::UdpSocket::bind(bind).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!(error = %e, "webrtc offer: failed to bind UDP socket");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to bind a media socket",
+            )
+                .into_response();
+        }
+    };
+
+    // Accept the browser offer → the str0m transport + the SDP answer.
+    let (transport, answer) =
+        match WebRtcTransport::accept_offer(&body.sdp, socket, WEBRTC_CARRIER_RATE) {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(error = %e, "webrtc offer: accept_offer failed");
+                return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
+            }
+        };
+
+    let run_id = state.next_pc.fetch_add(1, Ordering::Relaxed) as i64;
+    let pc_id = format!("pc-{run_id}");
+
+    // Register the live-event channel BEFORE returning the answer so opening
+    // markers aren't lost to a subscribe race.
+    let (call_events, guard) = state.events.register(&pc_id);
+    let sink: Arc<dyn RtviSink> = Arc::new(RtfSink::new(call_events));
+    let observers: Vec<Arc<dyn FrameObserver>> = vec![Arc::new(RtviObserver::new(sink))];
+
+    let session = StaticSession::new(
+        (*state.graph).clone(),
+        state.config.agent.seed_vars.clone(),
+        "webrtc",
+    );
+    let topology = state.config.topology.clone();
+    info!(pc_id = %pc_id, "webrtc offer accepted; running call detached");
+    let call_pc = pc_id.clone();
+    tokio::spawn(async move {
+        let _guard = guard; // deregister the live-event channel on call end
+        let res = run::run_call(
+            transport,
+            &topology,
+            brain,
+            session,
+            run_id,
+            String::new(),
+            observers,
+        )
+        .await;
+        match res {
+            Ok(()) => info!(pc_id = %call_pc, "webrtc call ended cleanly"),
+            Err(e) => error!(pc_id = %call_pc, error = %e, "webrtc call ended with error"),
+        }
+    });
+
+    Json(OfferResponse { sdp: answer, pc_id }).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ServerConfig;
+    use crate::server::{build_router, AppState};
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn state() -> AppState {
+        let config = ServerConfig::parse(
+            r#"{ "agent": { "graph_inline": {"nodes":[{"id":"s","type":"startCall","data":{"prompt":"hi"}},{"id":"e","type":"endCall"}],"edges":[{"id":"x","source":"s","target":"e","label":"done"}]} },
+                 "topology": { "mode": "realtime", "provider": "gemini" } }"#,
+            false,
+        )
+        .unwrap();
+        let graph = config.resolve_graph(std::path::Path::new(".")).unwrap();
+        AppState::new(config, graph, None)
+    }
+
+    #[tokio::test]
+    async fn playground_page_serves_html() {
+        let app = build_router(state());
+        let resp = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains("/webrtc/offer"),
+            "page must POST to /webrtc/offer"
+        );
+        assert!(html.contains("getUserMedia"), "page must capture the mic");
+    }
+
+    #[tokio::test]
+    async fn malformed_offer_is_422() {
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webrtc/offer")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"sdp":"not-a-valid-sdp"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // A graph this small is valid, so we get past the brain build; the junk SDP
+        // fails str0m's accept_offer → 422 (client error), no peer created.
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+}

--- a/flowcat-services/src/factory.rs
+++ b/flowcat-services/src/factory.rs
@@ -205,6 +205,11 @@ pub fn stt(spec: &ProviderSpec) -> Result<Box<dyn SttService>, FlowcatError> {
         #[cfg(feature = "stt-google")]
         "google" => {
             let project = spec.opt("project");
+            if project.is_empty() {
+                return Err(FlowcatError::Session(
+                    "google stt requires the `project` option (your GCP project id)".to_string(),
+                ));
+            }
             let location = {
                 let l = spec.opt("location");
                 if l.is_empty() {
@@ -471,7 +476,17 @@ pub fn realtime(spec: &ProviderSpec) -> Result<Box<dyn RealtimeBackend>, Flowcat
         }
     };
     match spec.provider.to_ascii_lowercase().as_str() {
-        "gemini" | "google" | "google_realtime" => Ok(Box::new(GeminiLive::new(key.to_string()))),
+        "gemini" | "google" | "google_realtime" => {
+            // Validate upfront (like the feature-gated realtime providers below) so a
+            // missing key is a clean error here, not a cryptic failure at connect time.
+            if key.trim().is_empty() {
+                return Err(FlowcatError::Realtime(
+                    "gemini realtime selected but no API key configured (set GOOGLE_API_KEY)"
+                        .to_string(),
+                ));
+            }
+            Ok(Box::new(GeminiLive::new(key.to_string())))
+        }
         #[cfg(feature = "realtime-openai")]
         "openai" | "openai_realtime" => {
             let key = require_realtime_key("openai", spec)?;
@@ -523,7 +538,7 @@ pub fn realtime(spec: &ProviderSpec) -> Result<Box<dyn RealtimeBackend>, Flowcat
             )))
         }
         "google_vertex" | "google_vertex_realtime" | "vertex_realtime" => {
-            if key.is_empty() {
+            if key.trim().is_empty() {
                 return Err(FlowcatError::Realtime(
                     "google_vertex realtime selected but no access token configured \
                      (set api_key to an OAuth2 access token)"
@@ -607,15 +622,36 @@ mod tests {
     }
 
     #[test]
-    fn realtime_gemini_always_builds_and_unknown_is_not_built() {
+    fn realtime_gemini_is_key_gated_and_unknown_is_not_built() {
+        // With a key, gemini builds.
         assert!(realtime(&spec("gemini", "k")).is_ok());
         assert!(realtime(&spec("GEMINI", "k")).is_ok());
+        // Without a key it is a clean error (not a cryptic connect-time failure).
+        let err = match realtime(&ProviderSpec::new("gemini")) {
+            Ok(_) => panic!("gemini realtime with no key should error"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("no API key configured"), "got: {err}");
+        // An unknown provider is a clean "not built" error naming the provider.
         let err = match realtime(&spec("banana", "k")) {
             Ok(_) => panic!("unknown realtime should not be built"),
             Err(e) => e.to_string(),
         };
         assert!(err.contains("not built"), "got: {err}");
         assert!(err.contains("banana"), "got: {err}");
+    }
+
+    #[cfg(feature = "stt-google")]
+    #[test]
+    fn google_stt_requires_a_project_option() {
+        // No `project` → a clean config error, not a malformed recognizer path.
+        let err = match stt(&spec("google", "token")) {
+            Ok(_) => panic!("google stt with no project should error"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("project"), "got: {err}");
+        // With a project it builds.
+        assert!(stt(&spec("google", "token").with_option("project", "my-proj")).is_ok());
     }
 
     // ── feature-gated provider coverage (run under the connector feature set) ──

--- a/flowcat-services/src/factory.rs
+++ b/flowcat-services/src/factory.rs
@@ -1,0 +1,670 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//! Provider **factory**: construct a boxed service from a provider *name* + options,
+//! instead of naming a concrete type at the call site. This is what lets a
+//! config-driven host (e.g. `flowcat-server`) pick providers from a YAML/JSON file
+//! — `factory::stt("deepgram", …)` rather than `DeepgramSttBuilder::new(…)`.
+//!
+//! Every provider arm is `#[cfg(feature = "…")]`-gated on the same flowcat-services
+//! feature that pulls the connector, so the **default build (`features = []`) builds
+//! none of them** and every name falls through to a clean "not built" error. Turning
+//! a provider on is a one-line Cargo feature add — no code change here.
+//!
+//! ## [`ProviderSpec`]
+//!
+//! A host-agnostic description of one provider selection: `provider`, `model`
+//! (for TTS this is the voice id), `api_key`, and an `options` map for the
+//! provider-specific extras some connectors need (region, base_url, project,
+//! location, endpoint, secret, group_id, url, join_url, language). The host fills
+//! these from its own config/env; flowcat-services never reads the environment.
+//!
+//! **Security:** the `api_key` is whatever the host resolves (typically from its
+//! own env/secret store). The factory never reads keys itself, so a per-call
+//! payload can't smuggle one in unless the host puts it in the `ProviderSpec`.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use flowcat_core::service::{LlmService, SttService, TtsService};
+use flowcat_core::{FlowcatError, GeminiLive, RealtimeBackend};
+// `ServiceRealtimeAdapter` is only referenced from the feature-gated realtime arms;
+// import it conditionally so the default (no-feature) build has no unused import.
+#[cfg(any(
+    feature = "realtime-openai",
+    feature = "realtime-grok",
+    feature = "realtime-inworld",
+    feature = "realtime-azure",
+    feature = "realtime-ultravox"
+))]
+use flowcat_core::ServiceRealtimeAdapter;
+
+/// A host-agnostic description of one provider selection.
+///
+/// `model` is the model id for STT/LLM/realtime; for **TTS it is the voice id**.
+/// `options` carries provider-specific extras (see the module docs for the keys
+/// each connector reads).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProviderSpec {
+    /// Provider name, e.g. `"deepgram"`, `"elevenlabs"`, `"openai"`, `"gemini"`.
+    pub provider: String,
+    /// Model id (STT/LLM/realtime) or **voice id** (TTS). Empty → the connector's
+    /// own default.
+    #[serde(default)]
+    pub model: String,
+    /// API key / token resolved by the host (never read from the environment here).
+    #[serde(default)]
+    pub api_key: String,
+    /// Provider-specific extras (region, base_url, project, location, endpoint,
+    /// secret, group_id, url, join_url, language, …).
+    #[serde(default)]
+    pub options: Map<String, Value>,
+}
+
+impl ProviderSpec {
+    /// A spec with just a provider name (everything else default).
+    pub fn new(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set the model (or, for TTS, the voice id).
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    /// Set the API key / token.
+    pub fn with_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = api_key.into();
+        self
+    }
+
+    /// Set one provider-specific option.
+    pub fn with_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.options.insert(key.into(), Value::String(value.into()));
+        self
+    }
+
+    /// Read a string option (empty string if absent), trimmed.
+    fn opt(&self, key: &str) -> String {
+        self.options
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_string()
+    }
+}
+
+/// "provider not built" error for an unknown / feature-disabled provider string.
+fn not_built(kind: &str, provider: &str) -> FlowcatError {
+    FlowcatError::Session(format!(
+        "{kind} provider {provider:?} is not built (enable its flowcat-services feature, \
+         or select a built provider)"
+    ))
+}
+
+/// Require a non-empty provider name + key for a cascaded leg (an empty key is a
+/// config error, not a silent fallback).
+fn require_key<'a>(kind: &str, spec: &'a ProviderSpec) -> Result<&'a str, FlowcatError> {
+    if spec.provider.trim().is_empty() {
+        return Err(FlowcatError::Session(format!(
+            "no {kind} provider configured"
+        )));
+    }
+    if spec.api_key.trim().is_empty() {
+        return Err(FlowcatError::Session(format!(
+            "no API key configured for the {kind} provider {:?}",
+            spec.provider
+        )));
+    }
+    Ok(spec.api_key.as_str())
+}
+
+/// Build the three cascaded services (STT, LLM, TTS) in one call. Boxed trait
+/// objects so they unify and hand straight to `build_cascaded_task`.
+#[allow(clippy::type_complexity)]
+pub fn cascaded(
+    stt_spec: &ProviderSpec,
+    llm_spec: &ProviderSpec,
+    tts_spec: &ProviderSpec,
+) -> Result<
+    (
+        Box<dyn SttService>,
+        Box<dyn LlmService>,
+        Box<dyn TtsService>,
+    ),
+    FlowcatError,
+> {
+    Ok((stt(stt_spec)?, llm(llm_spec)?, tts(tts_spec)?))
+}
+
+/// Build the STT service for `spec.provider`. Most clients take `new(api_key)`;
+/// a few read extras from `spec.options` (Azure `region`, Google `project`/
+/// `location`, Speaches `base_url`).
+#[allow(unused_variables)] // `key` is unused when no stt-* feature is enabled
+pub fn stt(spec: &ProviderSpec) -> Result<Box<dyn SttService>, FlowcatError> {
+    let key = require_key("stt", spec)?;
+    match spec.provider.to_ascii_lowercase().as_str() {
+        #[cfg(feature = "stt-deepgram")]
+        "deepgram" => {
+            let mut b = crate::stt::DeepgramSttBuilder::new(key);
+            if !spec.model.is_empty() {
+                b = b.model(&spec.model);
+            }
+            Ok(Box::new(b.build()))
+        }
+        #[cfg(feature = "stt-assemblyai")]
+        "assemblyai" => Ok(Box::new(crate::stt::AssemblyAiStt::new(key))),
+        #[cfg(feature = "stt-gladia")]
+        "gladia" => Ok(Box::new(crate::stt::GladiaStt::new(key))),
+        #[cfg(feature = "stt-soniox")]
+        "soniox" => Ok(Box::new(crate::stt::SonioxStt::new(key))),
+        #[cfg(feature = "stt-speechmatics")]
+        "speechmatics" => Ok(Box::new(crate::stt::SpeechmaticsStt::new(key))),
+        #[cfg(feature = "stt-cartesia")]
+        "cartesia" => Ok(Box::new(crate::stt::CartesiaStt::new(key))),
+        #[cfg(feature = "stt-elevenlabs")]
+        "elevenlabs" => {
+            let c = crate::stt::ElevenLabsStt::new(key);
+            Ok(Box::new(if spec.model.is_empty() {
+                c
+            } else {
+                c.model(&spec.model)
+            }))
+        }
+        #[cfg(feature = "stt-sarvam")]
+        "sarvam" => Ok(Box::new(crate::stt::SarvamStt::new(key))),
+        #[cfg(feature = "stt-openai")]
+        "openai" | "whisper" => Ok(Box::new(crate::stt::OpenAiStt::new(key))),
+        #[cfg(feature = "stt-groq")]
+        "groq" => Ok(Box::new(crate::stt::GroqStt::new(key))),
+        #[cfg(feature = "stt-fal")]
+        "fal" => Ok(Box::new(crate::stt::FalStt::new(key))),
+        #[cfg(feature = "stt-gradium")]
+        "gradium" => Ok(Box::new(crate::stt::GradiumStt::new(key))),
+        #[cfg(feature = "stt-mistral")]
+        "mistral" => Ok(Box::new(crate::stt::MistralStt::new(key))),
+        #[cfg(feature = "stt-speaches")]
+        "speaches" => {
+            let base = spec.opt("base_url");
+            Ok(Box::new(if base.is_empty() {
+                crate::stt::SpeachesStt::new(key)
+            } else {
+                crate::stt::SpeachesStt::with_base_url(key, base)
+            }))
+        }
+        #[cfg(feature = "stt-xai")]
+        "xai" => Ok(Box::new(crate::stt::XaiStt::new(key))),
+        #[cfg(feature = "stt-azure")]
+        "azure" | "azure_speech" => {
+            Ok(Box::new(crate::stt::AzureStt::new(key, spec.opt("region"))))
+        }
+        #[cfg(feature = "stt-google")]
+        "google" => {
+            let project = spec.opt("project");
+            let location = {
+                let l = spec.opt("location");
+                if l.is_empty() {
+                    "global".to_string()
+                } else {
+                    l
+                }
+            };
+            let recognizer = format!("projects/{project}/locations/{location}/recognizers/_");
+            Ok(Box::new(crate::stt::GoogleStt::new(key, recognizer)))
+        }
+        other => Err(not_built("stt", other)),
+    }
+}
+
+/// Build the TTS service for `spec.provider`. Clients take `new(api_key, voice)`;
+/// the voice is `spec.model` (empty → the provider's default voice). A few read
+/// extras from `spec.options` (MiniMax `group_id`, Azure `region`, Speaches
+/// `base_url`).
+#[allow(unused_variables)] // `key`/`voice` are unused when no tts-* feature is enabled
+pub fn tts(spec: &ProviderSpec) -> Result<Box<dyn TtsService>, FlowcatError> {
+    let key = require_key("tts", spec)?;
+    let voice = spec.model.clone();
+    match spec.provider.to_ascii_lowercase().as_str() {
+        #[cfg(feature = "tts-cartesia")]
+        "cartesia" => Ok(Box::new(crate::tts::CartesiaTts::new(key, voice))),
+        #[cfg(feature = "tts-elevenlabs")]
+        "elevenlabs" => Ok(Box::new(crate::tts::ElevenLabsTts::new(key, voice))),
+        #[cfg(feature = "tts-deepgram")]
+        "deepgram" => Ok(Box::new(crate::tts::DeepgramTts::new(key, voice))),
+        #[cfg(feature = "tts-rime")]
+        "rime" => Ok(Box::new(crate::tts::RimeTts::new(key, voice))),
+        #[cfg(feature = "tts-openai")]
+        "openai" => Ok(Box::new(crate::tts::OpenAiTts::new(key, voice))),
+        #[cfg(feature = "tts-sarvam")]
+        "sarvam" => Ok(Box::new(crate::tts::SarvamTts::new(key, voice))),
+        #[cfg(feature = "tts-hume")]
+        "hume" => Ok(Box::new(crate::tts::HumeTts::new(key, voice))),
+        #[cfg(feature = "tts-inworld")]
+        "inworld" => Ok(Box::new(crate::tts::InworldTts::new(key, voice))),
+        #[cfg(feature = "tts-asyncai")]
+        "asyncai" => Ok(Box::new(crate::tts::AsyncAiTts::new(key, voice))),
+        #[cfg(feature = "tts-camb")]
+        "camb" => Ok(Box::new(crate::tts::CambTts::new(key, voice))),
+        #[cfg(feature = "tts-fish")]
+        "fish" => Ok(Box::new(crate::tts::FishTts::new(key, voice))),
+        #[cfg(feature = "tts-gradium")]
+        "gradium" => Ok(Box::new(crate::tts::GradiumTts::new(key, voice))),
+        #[cfg(feature = "tts-groq")]
+        "groq" => Ok(Box::new(crate::tts::GroqTts::new(key, voice))),
+        #[cfg(feature = "tts-kokoro")]
+        "kokoro" => Ok(Box::new(crate::tts::KokoroTts::new(key, voice))),
+        #[cfg(feature = "tts-lmnt")]
+        "lmnt" => Ok(Box::new(crate::tts::LmntTts::new(key, voice))),
+        #[cfg(feature = "tts-mistral")]
+        "mistral" => Ok(Box::new(crate::tts::MistralTts::new(key, voice))),
+        #[cfg(feature = "tts-neuphonic")]
+        "neuphonic" => Ok(Box::new(crate::tts::NeuphonicTts::new(key, voice))),
+        #[cfg(feature = "tts-piper")]
+        "piper" => Ok(Box::new(crate::tts::PiperTts::new(key, voice))),
+        #[cfg(feature = "tts-resemble")]
+        "resemble" => Ok(Box::new(crate::tts::ResembleTts::new(key, voice))),
+        #[cfg(feature = "tts-smallest")]
+        "smallest" => Ok(Box::new(crate::tts::SmallestTts::new(key, voice))),
+        #[cfg(feature = "tts-soniox")]
+        "soniox" => Ok(Box::new(crate::tts::SonioxTts::new(key, voice))),
+        #[cfg(feature = "tts-speechmatics")]
+        "speechmatics" => Ok(Box::new(crate::tts::SpeechmaticsTts::new(key, voice))),
+        #[cfg(feature = "tts-xai")]
+        "xai" => Ok(Box::new(crate::tts::XaiTts::new(key, voice))),
+        #[cfg(feature = "tts-xtts")]
+        "xtts" => Ok(Box::new(crate::tts::XttsTts::new(key, voice))),
+        #[cfg(feature = "tts-minimax")]
+        "minimax" => Ok(Box::new(crate::tts::MiniMaxTts::new(
+            key,
+            spec.opt("group_id"),
+            voice,
+        ))),
+        #[cfg(feature = "tts-google")]
+        "google" => Ok(Box::new(crate::tts::GoogleTts::new(key, voice))),
+        #[cfg(feature = "tts-azure")]
+        "azure" | "azure_speech" => Ok(Box::new(crate::tts::AzureTts::new(
+            key,
+            spec.opt("region"),
+            voice,
+        ))),
+        #[cfg(feature = "tts-speaches")]
+        "speaches" => Ok(Box::new(crate::tts::SpeachesTts::new(
+            key,
+            spec.opt("base_url"),
+            voice,
+        ))),
+        other => Err(not_built("tts", other)),
+    }
+}
+
+/// Build an OpenAI-compatible LLM exposing `new(key)` + `with_model(key, model)`,
+/// applying the model override only when non-empty.
+#[allow(unused_macros)] // unused when no OpenAI-compatible llm-* feature is enabled
+macro_rules! oai_compat_llm {
+    ($ty:ty, $key:expr, $model:expr) => {
+        if $model.is_empty() {
+            <$ty>::new($key)
+        } else {
+            <$ty>::with_model($key, $model)
+        }
+    };
+}
+
+/// Build the LLM service for `spec.provider`. Most clients accept `new(api_key)`
+/// plus a `.model(m)` / `with_model(key, m)` override; a few read extras from
+/// `spec.options` (Vertex `project`/`location`, Azure `endpoint`, Bedrock
+/// `secret`/`region`).
+#[allow(unused_variables)] // `key`/`model` are unused when no llm-* feature is enabled
+pub fn llm(spec: &ProviderSpec) -> Result<Box<dyn LlmService>, FlowcatError> {
+    let key = require_key("llm", spec)?;
+    let model = spec.model.clone();
+    match spec.provider.to_ascii_lowercase().as_str() {
+        #[cfg(feature = "llm-openai")]
+        "openai" => {
+            let mut b = crate::llm::OpenAiLlmBuilder::new(key);
+            if !model.is_empty() {
+                b = b.model(model);
+            }
+            Ok(Box::new(b.build()))
+        }
+        #[cfg(feature = "llm-anthropic")]
+        "anthropic" => {
+            let c = crate::llm::AnthropicLlm::new(key);
+            Ok(Box::new(if model.is_empty() { c } else { c.model(model) }))
+        }
+        #[cfg(feature = "llm-google")]
+        "google" | "gemini" => {
+            let c = crate::llm::GoogleLlm::new(key);
+            Ok(Box::new(if model.is_empty() { c } else { c.model(model) }))
+        }
+        #[cfg(feature = "llm-google-vertex")]
+        "google_vertex" | "vertex" => {
+            let c =
+                crate::llm::GoogleVertexLlm::new(key, spec.opt("project"), spec.opt("location"));
+            Ok(Box::new(if model.is_empty() { c } else { c.model(model) }))
+        }
+        #[cfg(feature = "llm-groq")]
+        "groq" => Ok(Box::new(oai_compat_llm!(crate::llm::GroqLlm, key, model))),
+        #[cfg(feature = "llm-together")]
+        "together" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::TogetherLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-openrouter")]
+        "openrouter" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::OpenRouterLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-deepseek")]
+        "deepseek" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::DeepSeekLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-mistral")]
+        "mistral" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::MistralLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-cerebras")]
+        "cerebras" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::CerebrasLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-minimax")]
+        "minimax" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::MiniMaxLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-fireworks")]
+        "fireworks" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::FireworksLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-nebius")]
+        "nebius" => Ok(Box::new(oai_compat_llm!(crate::llm::NebiusLlm, key, model))),
+        #[cfg(feature = "llm-novita")]
+        "novita" => Ok(Box::new(oai_compat_llm!(crate::llm::NovitaLlm, key, model))),
+        #[cfg(feature = "llm-perplexity")]
+        "perplexity" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::PerplexityLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-qwen")]
+        "qwen" => Ok(Box::new(oai_compat_llm!(crate::llm::QwenLlm, key, model))),
+        #[cfg(feature = "llm-sambanova")]
+        "sambanova" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::SambaNovaLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-nvidia-nim")]
+        "nvidia_nim" | "nvidia-nim" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::NvidiaNimLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-grok")]
+        "grok" => Ok(Box::new(oai_compat_llm!(crate::llm::GrokLlm, key, model))),
+        #[cfg(feature = "llm-ollama")]
+        "ollama" => Ok(Box::new(oai_compat_llm!(crate::llm::OllamaLlm, key, model))),
+        #[cfg(feature = "llm-sarvam")]
+        "sarvam" => Ok(Box::new(oai_compat_llm!(crate::llm::SarvamLlm, key, model))),
+        #[cfg(feature = "llm-speaches")]
+        "speaches" => Ok(Box::new(oai_compat_llm!(
+            crate::llm::SpeachesLlm,
+            key,
+            model
+        ))),
+        #[cfg(feature = "llm-openai-responses")]
+        "openai_responses" | "openai-responses" => {
+            let c = crate::llm::OpenAiResponsesLlm::new(key);
+            Ok(Box::new(if model.is_empty() { c } else { c.model(model) }))
+        }
+        #[cfg(feature = "llm-azure")]
+        "azure" => Ok(Box::new(crate::llm::AzureLlm::new(
+            key,
+            spec.opt("endpoint"),
+            model,
+        ))),
+        #[cfg(feature = "llm-aws-bedrock")]
+        "aws_bedrock" | "bedrock" => Ok(Box::new(crate::llm::AwsBedrockLlm::new(
+            key,
+            spec.opt("secret"),
+            spec.opt("region"),
+            model,
+        ))),
+        other => Err(not_built("llm", other)),
+    }
+}
+
+/// Build the realtime (speech-to-speech) backend for `spec.provider`.
+///
+/// `gemini` is flowcat-core's [`GeminiLive`] (implements the pipeline traits
+/// directly); every flowcat-services realtime connector is wrapped in
+/// [`ServiceRealtimeAdapter`], which presents it as the pipeline's
+/// `RealtimeLlm + RealtimeKickoff`. Both coerce to one `Box<dyn RealtimeBackend>`.
+///
+/// Option keys: `language` (input-transcription hint, OpenAI-family), `url`
+/// (Azure deployment WSS URL), `join_url` (Ultravox per-call URL), `project` /
+/// `location` (Google Vertex).
+#[allow(unused_variables)] // `language` is unused when no realtime-openai feature is enabled
+pub fn realtime(spec: &ProviderSpec) -> Result<Box<dyn RealtimeBackend>, FlowcatError> {
+    let key = spec.api_key.as_str();
+    let language = {
+        let l = spec.opt("language");
+        if l.is_empty() {
+            None
+        } else {
+            Some(l)
+        }
+    };
+    match spec.provider.to_ascii_lowercase().as_str() {
+        "gemini" | "google" | "google_realtime" => Ok(Box::new(GeminiLive::new(key.to_string()))),
+        #[cfg(feature = "realtime-openai")]
+        "openai" | "openai_realtime" => {
+            let key = require_realtime_key("openai", spec)?;
+            Ok(Box::new(ServiceRealtimeAdapter::new(
+                crate::realtime::OpenAiRealtime::new(key).with_input_language(language),
+            )))
+        }
+        #[cfg(feature = "realtime-grok")]
+        "grok" | "grok_realtime" => {
+            let key = require_realtime_key("grok", spec)?;
+            Ok(Box::new(ServiceRealtimeAdapter::new(
+                crate::realtime::GrokRealtime::new(key),
+            )))
+        }
+        #[cfg(feature = "realtime-inworld")]
+        "inworld" | "inworld_realtime" => {
+            let key = require_realtime_key("inworld", spec)?;
+            Ok(Box::new(ServiceRealtimeAdapter::new(
+                crate::realtime::InworldRealtime::new(key),
+            )))
+        }
+        #[cfg(feature = "realtime-azure")]
+        "azure" | "azure_realtime" => {
+            let key = require_realtime_key("azure", spec)?;
+            let url = spec.opt("url");
+            if url.is_empty() {
+                return Err(FlowcatError::Realtime(
+                    "azure realtime selected but no endpoint URL configured \
+                     (set option `url` to the full deployment WSS URL)"
+                        .to_string(),
+                ));
+            }
+            Ok(Box::new(ServiceRealtimeAdapter::new(
+                crate::realtime::AzureRealtime::new(key, url),
+            )))
+        }
+        #[cfg(feature = "realtime-ultravox")]
+        "ultravox" | "ultravox_realtime" => {
+            let join_url = spec.opt("join_url");
+            if join_url.is_empty() {
+                return Err(FlowcatError::Realtime(
+                    "ultravox realtime selected but no join URL configured \
+                     (set option `join_url`; mint one per call via the Ultravox REST API)"
+                        .to_string(),
+                ));
+            }
+            Ok(Box::new(ServiceRealtimeAdapter::new(
+                crate::realtime::UltravoxRealtime::new(join_url),
+            )))
+        }
+        "google_vertex" | "google_vertex_realtime" | "vertex_realtime" => {
+            if key.is_empty() {
+                return Err(FlowcatError::Realtime(
+                    "google_vertex realtime selected but no access token configured \
+                     (set api_key to an OAuth2 access token)"
+                        .to_string(),
+                ));
+            }
+            Ok(Box::new(GeminiLive::new_vertex(
+                key.to_string(),
+                spec.opt("project"),
+                spec.opt("location"),
+            )))
+        }
+        other => Err(FlowcatError::Realtime(format!(
+            "realtime provider {other:?} is not built (gemini, openai, grok, inworld, azure, \
+             ultravox, google_vertex are wired; enable the matching flowcat-services realtime \
+             feature to add more)"
+        ))),
+    }
+}
+
+/// Require a non-empty key for a realtime provider; clean error naming the field.
+#[cfg(any(
+    feature = "realtime-openai",
+    feature = "realtime-grok",
+    feature = "realtime-inworld",
+    feature = "realtime-azure"
+))]
+fn require_realtime_key(provider: &str, spec: &ProviderSpec) -> Result<String, FlowcatError> {
+    if spec.api_key.trim().is_empty() {
+        return Err(FlowcatError::Realtime(format!(
+            "{provider} realtime selected but no key configured (set api_key)"
+        )));
+    }
+    Ok(spec.api_key.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(provider: &str, key: &str) -> ProviderSpec {
+        ProviderSpec::new(provider).with_key(key)
+    }
+
+    fn cascaded_err(stt_p: &str, tts_p: &str, llm_p: &str) -> String {
+        match cascaded(&spec(stt_p, "k"), &spec(llm_p, "k"), &spec(tts_p, "k")) {
+            Ok(_) => panic!("expected the factory to error"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn unknown_provider_is_a_clean_not_built_error() {
+        let err = cascaded_err("nope-stt", "cartesia", "openai");
+        assert!(
+            err.contains("not built"),
+            "expected 'not built', got: {err}"
+        );
+        assert!(err.contains("nope-stt"));
+    }
+
+    #[test]
+    fn empty_key_is_a_config_error_not_a_panic() {
+        let err = match stt(&ProviderSpec::new("deepgram")) {
+            Ok(_) => panic!("expected a key error"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.to_lowercase().contains("key"),
+            "expected a key error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_provider_is_a_config_error() {
+        let err = match llm(&ProviderSpec::default()) {
+            Ok(_) => panic!("expected a provider error"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("no llm provider configured"), "got: {err}");
+    }
+
+    #[test]
+    fn realtime_gemini_always_builds_and_unknown_is_not_built() {
+        assert!(realtime(&spec("gemini", "k")).is_ok());
+        assert!(realtime(&spec("GEMINI", "k")).is_ok());
+        let err = match realtime(&spec("banana", "k")) {
+            Ok(_) => panic!("unknown realtime should not be built"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("not built"), "got: {err}");
+        assert!(err.contains("banana"), "got: {err}");
+    }
+
+    // ── feature-gated provider coverage (run under the connector feature set) ──
+
+    #[cfg(all(
+        feature = "stt-deepgram",
+        feature = "tts-cartesia",
+        feature = "llm-openai"
+    ))]
+    #[test]
+    fn factory_builds_the_reference_trio() {
+        assert!(cascaded(
+            &spec("deepgram", "k"),
+            &spec("openai", "k"),
+            &spec("cartesia", "k")
+        )
+        .is_ok());
+    }
+
+    #[cfg(feature = "stt-elevenlabs")]
+    #[test]
+    fn elevenlabs_stt_builds_with_and_without_model() {
+        assert!(stt(&spec("elevenlabs", "k")).is_ok());
+        assert!(stt(&spec("elevenlabs", "k").with_model("scribe_v1")).is_ok());
+    }
+
+    #[cfg(feature = "tts-minimax")]
+    #[test]
+    fn minimax_tts_builds_with_group_id_option() {
+        assert!(tts(&spec("minimax", "k")
+            .with_option("group_id", "grp-1")
+            .with_model("voice-1"))
+        .is_ok());
+    }
+
+    #[cfg(feature = "stt-azure")]
+    #[test]
+    fn azure_stt_reads_region_option() {
+        assert!(stt(&spec("azure", "k").with_option("region", "eastus")).is_ok());
+    }
+
+    #[cfg(feature = "realtime-openai")]
+    #[test]
+    fn openai_realtime_is_key_gated() {
+        // Wired, but key-gated: no key → a "no key" error, not "not built".
+        let err = match realtime(&ProviderSpec::new("openai")) {
+            Ok(_) => panic!("openai realtime should be key-gated"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("no key configured"), "got: {err}");
+    }
+}

--- a/flowcat-services/src/lib.rs
+++ b/flowcat-services/src/lib.rs
@@ -33,6 +33,11 @@ pub mod tts;
 
 pub mod llm;
 
+/// Provider **factory** — construct a boxed service from a provider *name* +
+/// options (string → `Box<dyn SttService>` etc.), for config-driven hosts.
+pub mod factory;
+pub use factory::ProviderSpec;
+
 pub mod observability;
 
 /// MCP-as-processor (pulls an MCP/HTTP client → sibling, not core).

--- a/flowcat-telephony/src/lib.rs
+++ b/flowcat-telephony/src/lib.rs
@@ -67,7 +67,7 @@ pub use twilio::TwilioSerializer;
 pub use telnyx::{Encoding as TelnyxEncoding, TelnyxSerializer};
 
 #[cfg(feature = "plivo")]
-pub use plivo::PlivoSerializer;
+pub use plivo::{plivo_answer_xml, PlivoSerializer};
 
 #[cfg(feature = "exotel")]
 pub use exotel::ExotelSerializer;

--- a/flowcat-telephony/src/plivo.rs
+++ b/flowcat-telephony/src/plivo.rs
@@ -280,3 +280,74 @@ mod tests {
         assert_eq!(PlivoSerializer::new(8000).carrier_rate(), 8000);
     }
 }
+
+// ── Plivo call-answer XML ──────────────────────────────────────────────────────
+
+/// Minimal XML escaper for the value embedded in the answer XML (a URL): `&`,
+/// `<`, `>`. The raw `&` separating query params would otherwise start an XML
+/// entity and Plivo rejects the document ("Invalid Answer XML").
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Map an `http(s)://` public base to the matching `ws(s)://` scheme.
+fn ws_scheme(public_base: &str) -> String {
+    public_base
+        .replace("https://", "wss://")
+        .replace("http://", "ws://")
+}
+
+/// Build the Plivo answer XML for a run: a bidirectional μ-law/8 kHz `<Stream>`
+/// pointing back at this host's media WebSocket
+/// (`/telephony/ws/plivo/{run_id}?token=`), carrying the per-call `token`.
+///
+/// `public_base` is this host's public URL (e.g. `https://voice.example.com`);
+/// the trailing slash is trimmed and the scheme is mapped to `ws(s)://`.
+///
+/// `keepCallAlive="true"` is required: Plivo's `<Stream>` verb is non-blocking, so
+/// without it Plivo hits "End Of XML Instructions" and hangs the call up at ~1s,
+/// before a single word. The trailing `<Hangup/>` runs when the agent ends the
+/// call and the media WS closes, hanging the leg up cleanly instead of leaving it
+/// connected and silent.
+pub fn plivo_answer_xml(run_id: i64, token: &str, public_base: &str) -> String {
+    let base = public_base.trim_end_matches('/');
+    let wss_base = ws_scheme(base);
+    let ws_url = format!("{wss_base}/telephony/ws/plivo/{run_id}?token={token}");
+    let ws_url_xml = xml_escape(&ws_url);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?><Response><Stream contentType="audio/x-mulaw;rate=8000" bidirectional="true" keepCallAlive="true">{ws_url_xml}</Stream><Hangup/></Response>"#
+    )
+}
+
+#[cfg(test)]
+mod answer_xml_tests {
+    use super::plivo_answer_xml;
+
+    #[test]
+    fn https_base_becomes_wss_and_query_amp_is_escaped() {
+        let xml = plivo_answer_xml(42, "tok-abc", "https://voice.example.com/");
+        assert!(
+            xml.contains("wss://voice.example.com/telephony/ws/plivo/42?token=tok-abc"),
+            "ws url wrong: {xml}"
+        );
+        // Bidirectional μ-law stream with keepCallAlive="true" + a trailing <Hangup/>.
+        assert!(xml.contains(
+            r#"<Stream contentType="audio/x-mulaw;rate=8000" bidirectional="true" keepCallAlive="true">"#
+        ));
+        assert!(
+            xml.contains("</Stream><Hangup/></Response>"),
+            "trailing <Hangup/> must run on WS close: {xml}"
+        );
+        // A `&` in the base (multi-param query) must be escaped or Plivo rejects it.
+        let xml2 = plivo_answer_xml(7, "t", "https://h.example/a?x=1&y=2");
+        assert!(xml2.contains("&amp;"), "ampersand must be escaped: {xml2}");
+    }
+
+    #[test]
+    fn http_base_becomes_ws() {
+        let xml = plivo_answer_xml(1, "tok", "http://localhost:6210");
+        assert!(xml.contains("ws://localhost:6210/telephony/ws/plivo/1?token=tok"));
+    }
+}

--- a/website/src/api-reference.md
+++ b/website/src/api-reference.md
@@ -30,9 +30,11 @@ the same features you'd build with (see [Deployment](./deployment.md#1-build-a-r
 | Crate | What it exposes |
 |---|---|
 | [`flowcat-core`](https://github.com/AreevAI/flowcat/tree/main/flowcat-core) | The seams and runtime: `AgentBrain`, `SessionSource`, `MediaTransport`, `RealtimeLlm` / `RealtimeKickoff`, the `FrameProcessor` graph + `Frame` taxonomy, `build_s2s_task` / `build_cascaded_task`, native `SipAgent` / `SipTransport`, and the `GeminiLive` backend |
-| [`flowcat-services`](https://github.com/AreevAI/flowcat/tree/main/flowcat-services) | STT / TTS / LLM / realtime provider adapters (feature-gated), observability exporters, the `RemoteBrain` HTTP adapter (`brain-http`) |
+| [`flowcat-services`](https://github.com/AreevAI/flowcat/tree/main/flowcat-services) | STT / TTS / LLM / realtime provider adapters (feature-gated), the provider-by-name `factory`, observability exporters, the `RemoteBrain` HTTP adapter (`brain-http`) |
 | [`flowcat-transports`](https://github.com/AreevAI/flowcat/tree/main/flowcat-transports) | WebRTC (`webrtc-str0m`), WebSocket (`ws`), and other media transports |
 | [`flowcat-telephony`](https://github.com/AreevAI/flowcat/tree/main/flowcat-telephony) | Carrier serializers (Plivo, Twilio, Telnyx, …) and DTMF |
+| [`flowcat-agent`](https://github.com/AreevAI/flowcat/tree/main/flowcat-agent) | Declarative graph agent — a config-driven `AgentBrain` (`DeclarativeBrain`) over a node/edge graph spec |
+| [`flowcat-server`](https://github.com/AreevAI/flowcat/tree/main/flowcat-server) | Config-driven single-agent HTTP server (`ServerConfig` + `StaticSession`) + the browser WebRTC playground (`webrtc` feature) |
 | [`flowcat-cli`](https://github.com/AreevAI/flowcat/tree/main/flowcat-cli) | The credential-free `flowcat` demo binary (`pipeline`, `ws-echo`) |
 
 ## Starting points

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -14,6 +14,14 @@ environment in production.** Setting `OPENAI_API_KEY` does not make a running
 Flowcat pick it up — your embedder reads its own credentials however it likes and
 passes them to the provider constructor.
 
+> **Running the bundled
+> [`flowcat-server`](./quickstart.md#5-talk-to-a-real-agent-in-your-browser-no-rust)
+> rather than embedding?** That binary *is* the config-driven host: it takes a
+> YAML/JSON config (the agent graph + provider topology) and *does* read provider
+> keys from the environment (`<PROVIDER>_API_KEY`, e.g. `GOOGLE_API_KEY`), so you
+> don't write one yourself. The "no config file / no env keys" rule above is about
+> embedding the **library** directly. Schema: `flowcat-server/src/config.rs`.
+
 > Contributing to Flowcat and running the live integration tests? Those use their
 > own `*_API_KEY` environment variables — see
 > [Building and running tests](./contributing.md#building-and-running-tests).

--- a/website/src/deployment.md
+++ b/website/src/deployment.md
@@ -5,11 +5,13 @@ air-gapped). Flowcat is one self-contained binary with no hosted control plane
 and no phone-home — deployment is "ship a binary, open the right ports, give it
 your provider credentials."
 
-> **What you actually deploy is *your* [embedder](./embedder.md)** — the small
-> host binary that terminates calls and supplies the brain. The bundled
-> `flowcat` CLI (`pipeline`, `ws-echo`) is for credential-free demos, **not** a
-> production server. Everything below applies to the release binary you build
-> from your embedder crate; the build mechanics are identical.
+> **Two ways to deploy.** The bundled **`flowcat-server`** binary runs one agent
+> from a YAML config (no Rust) and is deployable on its own — start with its
+> [Docker setup](https://github.com/AreevAI/flowcat/tree/main/deploy) and the
+> [Quickstart](./quickstart.md#5-talk-to-a-real-agent-in-your-browser-no-rust). For
+> full control you instead ship *your own* [embedder](./embedder.md). Either way the
+> build mechanics below are identical; the credential-free `flowcat` CLI
+> (`pipeline`, `ws-echo`) is for demos, **not** a server.
 
 ---
 
@@ -63,8 +65,20 @@ libraries — Whisper, ONNX — may need the matching musl system libraries.)
 
 ## 2. Containerize
 
-There is **no official image yet** — the only `Dockerfile` in the repo is the
-benchmark harness under `bench/`. A production multi-stage build is small:
+The repo ships a multi-stage
+[`Dockerfile`](https://github.com/AreevAI/flowcat/blob/main/Dockerfile) that builds
+**`flowcat-server`**, plus a
+[`deploy/`](https://github.com/AreevAI/flowcat/tree/main/deploy) compose file +
+sample config + env template:
+
+```bash
+cp deploy/.env.example deploy/.env          # fill the provider key(s) you use
+FLOWCAT_FEATURES=webrtc \
+  docker compose -f deploy/docker-compose.yml up --build   # then open :6210
+```
+
+To containerize *your own embedder* instead, the same multi-stage pattern applies
+— swap the build package + features and the `EXPOSE`d ports for your transport:
 
 ```dockerfile
 # ---- build ----

--- a/website/src/introduction.md
+++ b/website/src/introduction.md
@@ -15,21 +15,36 @@ pipeline model and the same provider breadth, packaged for teams that need to
 **own the stack** — self-hosted, auditable, and dense enough to run serious call
 volume per box.
 
-**License:** Apache-2.0 · **Status:** pre-1.0, building in the open.
+<!-- Overview video — replace VIDEO_ID with the YouTube id (the part after
+     youtu.be/ or watch?v=). Rendered by mdBook on the docs home page; GitHub
+     strips iframes from README.md, which is why this lives in the site source. -->
+<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:960px;margin:1.5rem auto;border-radius:8px;">
+  <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
+    src="https://www.youtube-nocookie.com/embed/VIDEO_ID"
+    title="Flowcat — overview"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen></iframe>
+</div>
 
-> **New here?** The [Quickstart](./quickstart.md) takes you from `git clone` to a
-> running pipeline, a real WebSocket audio round-trip, and a Python-driven brain
-> in about five minutes — no credentials.
+**Status:** pre-1.0, building in the open.
+
+> **New here?** The [Quickstart](./quickstart.md) goes from `git clone` to a
+> running pipeline and a real audio round-trip in about five minutes (no
+> credentials), then to a **real agent you talk to in your browser** — defined in
+> YAML and run with one binary (`flowcat-server`), no Rust required.
 
 ## Where to go next
 
 **Building on Flowcat?** Follow the path in order:
 
-1. **[Quickstart](./quickstart.md)** — clone → build → watch real audio move.
-2. **[Build an embedder](./embedder.md)** — the host binary that carries a call.
+1. **[Quickstart](./quickstart.md)** — clone → build → watch real audio move, then
+   talk to a real agent in your browser (`flowcat-server`, no Rust).
+2. **[Build an embedder](./embedder.md)** — the host binary that carries a call,
+   when you need more than the config-driven server.
 3. **[Configuration](./configuration.md)** — runtime knobs and credentials.
 4. **[Providers & features](./features.md)** — the STT / TTS / LLM / transport surface.
-5. **[Deployment](./deployment.md)** — ship a release binary in your own VPC.
+5. **[Deployment](./deployment.md)** — ship a release binary (or `flowcat-server`) in your own VPC.
 
 **Contributing to Flowcat?** Start with
 **[Contributing](./contributing.md)** (build, test, add a provider) and the

--- a/website/src/introduction.md
+++ b/website/src/introduction.md
@@ -15,12 +15,12 @@ pipeline model and the same provider breadth, packaged for teams that need to
 **own the stack** — self-hosted, auditable, and dense enough to run serious call
 volume per box.
 
-<!-- Overview video — replace VIDEO_ID with the YouTube id (the part after
-     youtu.be/ or watch?v=). Rendered by mdBook on the docs home page; GitHub
-     strips iframes from README.md, which is why this lives in the site source. -->
+<!-- Overview video (https://youtu.be/XuR4jfJofhg). Rendered by mdBook on the docs
+     home page; GitHub strips iframes from README.md, so the README links a
+     clickable thumbnail to the same video instead. -->
 <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:960px;margin:1.5rem auto;border-radius:8px;">
   <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
-    src="https://www.youtube-nocookie.com/embed/VIDEO_ID"
+    src="https://www.youtube-nocookie.com/embed/XuR4jfJofhg"
     title="Flowcat — overview"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     referrerpolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
Turns flowcat from "a runtime you wire by hand" into "define an agent in YAML and run a binary." Builds on the `flowcat-agent` crate (declarative graph brain) landed earlier. Five self-contained commits, each tested before commit.

## What's in it

**Phase 0 — foundations**
- **`flowcat-services::factory`** (FR-2): `stt()/tts()/llm()/realtime()/cascaded()` build a boxed service from a provider *name* + a host-agnostic `ProviderSpec` (string → `Box<dyn …>`). Every provider arm is feature-gated, so the default build builds none and unknown/disabled names return a clean "not built" error. Env-free (a generic `ProviderSpec` replaces host `Config`/env reads).
- **`flowcat-server::config`** (FR-3): `ServerConfig` schema + YAML/JSON loader (agent graph, `realtime`/`cascaded` topology, transport, bind). Keys are never in the file.
- **`flowcat-server::session::StaticSession`** (FR-4): a control-plane-free `SessionSource` (resolve returns the configured agent; artifacts → local dir) — so any user can run a real call with no control plane.

**Phase 1 — the server**
- **`flowcat-server` binary** (FR-5): `flowcat-server --config agent.yaml` boots an axum server (`/healthz`, `/readyz`, the Plivo media WebSocket, the Plivo answer XML) that runs the configured agent. `run_call` assembles `build_s2s_task` / `build_cascaded_call` from the topology; provider keys resolve from env (`<PROVIDER>_API_KEY`, `GOOGLE_API_KEY` for Gemini). `AxumWsSocket` adapts an inbound axum WS to `MediaSocket`.
- **`flowcat-telephony::plivo_answer_xml`** (FR-9).

**Phase 2 — browser playground** (behind the `webrtc` feature)
- **`POST /webrtc/offer`** (FR-6): accepts a browser SDP offer, builds the str0m `WebRtcTransport`, runs the agent detached.
- **live events** (FR-7): `RtviObserver` → `RtfSink` → per-call channel, streamed over `/webrtc/events/{pc_id}`.
- **`GET /`** (FR-8): a self-contained vanilla-JS playground (mic → WebRTC → audio + live transcript), embedded in the binary.

**Phase 3 — deploy** (FR-10): multi-stage `Dockerfile`, `deploy/` compose + `.env.example` + `agent.example.yaml` + quickstart.

## Feature gating (default build stays dependency-free)

`flowcat-server` default build is library-only (config + session + run). The HTTP server is behind `server`; the WebRTC playground behind `webrtc`. `flowcat-cli`'s default build pulls **no** `axum`/`tokio`/`str0m`/`chrono`/`flowcat-server`. The provider factory's default build builds no connectors.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --workspace -D warnings` clean (default, `server`, and `webrtc` feature modes).
- Full test suite green: workspace default (incl. flowcat-core's 281), `flowcat-server --features webrtc` (19, incl. axum router oneshot tests + str0m SDP rejection + event registry/mapping), factory across all ~80 connectors (9).
- **Ran the binary**: `/healthz` → 200, `/` serves the playground, `/readyz` → 503 without a key, `POST /webrtc/offer` reaches str0m's real SDP parser; boots cleanly from `deploy/agent.example.yaml`; `docker compose config` validates.

## Honest scope note

A **live voice call** (and a real browser session on the playground) additionally needs a provider API key and a browser — not exercisable in CI, so those paths are offline/fixture-tested + the binary is run-verified, matching flowcat's existing "fixture-tested ≠ live-verified" bar.

## Follow-ups (not in this PR)

- Optional `escalation_targets` rename in `flowcat-agent` (deferred; backward-compat alias).
- SIP transport in the server (the native SIP UA exists in `flowcat-core`; wiring the trunk lifecycle into the config-driven server is a separate feature).
