### PR TITLE
flowcat-server: injectable framework (generic session/brain, provider resolver, reusable WebRTC handle_offer) (#20, #21, #22)

### DIFF
--- a/flowcat-core/src/session.rs
+++ b/flowcat-core/src/session.rs
@@ -8,6 +8,8 @@
 //! "Trait contracts"). [`ResolvedCall`], [`Finalize`], [`UploadTarget`], and
 //! [`Usage`] are defined in [`crate::types`] and re-exported here.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::error::FlowcatError;
@@ -72,4 +74,148 @@ pub trait SessionSource: Send + Sync {
         tool_name: &str,
         args: &serde_json::Value,
     ) -> Result<String, FlowcatError>;
+}
+
+/// Blanket impl for any `Arc`-wrapped source (including `Arc<dyn SessionSource>`).
+///
+/// A real deployment holds **one** session (its control-plane HTTP client, pools,
+/// caches) and reuses it across every call. The per-call pipeline builders take a
+/// `SessionSource` *by value*, so this impl lets a shared `Arc<S>` be cloned cheaply
+/// per call and passed in without forcing the concrete source to be `Clone` — and,
+/// via `?Sized`, lets an embedder erase the source to `Arc<dyn SessionSource>`.
+#[async_trait]
+impl<T: SessionSource + ?Sized> SessionSource for Arc<T> {
+    async fn resolve(&self, run_id: i64, token: &str) -> Result<ResolvedCall, FlowcatError> {
+        (**self).resolve(run_id, token).await
+    }
+
+    async fn complete(&self, run_id: i64, token: &str, fin: Finalize) -> Result<(), FlowcatError> {
+        (**self).complete(run_id, token, fin).await
+    }
+
+    async fn artifact_upload_url(
+        &self,
+        run_id: i64,
+        token: &str,
+        kind: &str,
+    ) -> Result<UploadTarget, FlowcatError> {
+        (**self).artifact_upload_url(run_id, token, kind).await
+    }
+
+    async fn put_bytes(
+        &self,
+        url: &str,
+        bytes: Vec<u8>,
+        content_type: &str,
+    ) -> Result<(), FlowcatError> {
+        (**self).put_bytes(url, bytes, content_type).await
+    }
+
+    async fn node_tools(
+        &self,
+        run_id: i64,
+        token: &str,
+        node_id: &str,
+    ) -> Result<Vec<ToolDecl>, FlowcatError> {
+        (**self).node_tools(run_id, token, node_id).await
+    }
+
+    async fn tool_call(
+        &self,
+        run_id: i64,
+        token: &str,
+        node_id: &str,
+        tool_name: &str,
+        args: &serde_json::Value,
+    ) -> Result<String, FlowcatError> {
+        (**self)
+            .tool_call(run_id, token, node_id, tool_name, args)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    /// Minimal source that records how many times `resolve` was called and echoes a
+    /// fixed provider, so the blanket `Arc` impl can be observed delegating.
+    struct CountingSource {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SessionSource for CountingSource {
+        async fn resolve(&self, _run_id: i64, _token: &str) -> Result<ResolvedCall, FlowcatError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(ResolvedCall {
+                provider: "counting".to_string(),
+                brain_config: json!({ "graph_spec": {} }),
+                is_completed: false,
+            })
+        }
+        async fn complete(
+            &self,
+            _run_id: i64,
+            _token: &str,
+            _fin: Finalize,
+        ) -> Result<(), FlowcatError> {
+            Ok(())
+        }
+        async fn artifact_upload_url(
+            &self,
+            _run_id: i64,
+            _token: &str,
+            _kind: &str,
+        ) -> Result<UploadTarget, FlowcatError> {
+            Err(FlowcatError::Session("not supported".into()))
+        }
+        async fn put_bytes(
+            &self,
+            _url: &str,
+            _bytes: Vec<u8>,
+            _content_type: &str,
+        ) -> Result<(), FlowcatError> {
+            Ok(())
+        }
+        async fn node_tools(
+            &self,
+            _run_id: i64,
+            _token: &str,
+            _node_id: &str,
+        ) -> Result<Vec<ToolDecl>, FlowcatError> {
+            Ok(vec![])
+        }
+        async fn tool_call(
+            &self,
+            _run_id: i64,
+            _token: &str,
+            _node_id: &str,
+            tool_name: &str,
+            _args: &Value,
+        ) -> Result<String, FlowcatError> {
+            Ok(tool_name.to_string())
+        }
+    }
+
+    // Generic over `SessionSource` by value — the call site that motivates the
+    // blanket impl (e.g. the per-call pipeline builders).
+    async fn resolve_via<S: SessionSource>(s: S) -> ResolvedCall {
+        s.resolve(7, "tok").await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn arc_delegates_and_satisfies_session_source_by_value() {
+        let inner = Arc::new(CountingSource {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        // Concrete `Arc<S>`: clone it per "call" and pass each by value.
+        assert_eq!(resolve_via(inner.clone()).await.provider, "counting");
+        assert_eq!(resolve_via(inner.clone()).await.provider, "counting");
+        // Type-erased `Arc<dyn SessionSource>` works through the same impl.
+        let erased: Arc<dyn SessionSource> = inner.clone();
+        assert_eq!(resolve_via(erased).await.provider, "counting");
+        assert_eq!(inner.calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
 }

--- a/flowcat-server/src/events.rs
+++ b/flowcat-server/src/events.rs
@@ -25,6 +25,7 @@ use tokio::sync::mpsc;
 use tracing::debug;
 
 use flowcat_core::observer::{RtviMessage, RtviSink};
+use flowcat_core::{AgentBrain, SessionSource};
 
 use crate::server::AppState;
 
@@ -146,12 +147,17 @@ fn map_rtvi_to_rtf(m: &RtviMessage) -> Option<(&'static str, Value)> {
 }
 
 /// `GET /webrtc/events/{pc_id}` — stream a call's `rtf-*` frames to the browser.
-/// Serves only a registered `pc_id` (unknown → 404).
-pub async fn events_ws(
-    State(state): State<AppState>,
+/// Serves only a registered `pc_id` (unknown → 404). Generic over the embedder's
+/// session/brain so it shares the one [`AppState`] the rest of the router uses.
+pub async fn events_ws<S, B>(
+    State(state): State<AppState<S, B>>,
     Path(pc_id): Path<String>,
     ws: WebSocketUpgrade,
-) -> Response {
+) -> Response
+where
+    S: SessionSource + 'static,
+    B: AgentBrain + 'static,
+{
     let Some(rx) = state.events.take_receiver(&pc_id) else {
         return (StatusCode::NOT_FOUND, "no such call").into_response();
     };

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -15,6 +15,17 @@
 //! HTTP server (health, the Plivo media WebSocket, the Plivo answer XML) that runs
 //! the configured agent. The default (no-feature) build is library-only and pulls
 //! no axum/tokio.
+//!
+//! ## A reusable framework, not just a binary
+//!
+//! With the `server` feature, the HTTP/transport surface (`build_router` over
+//! `AppState`) is **generic over the embedder's `SessionSource` and `AgentBrain`**.
+//! The zero-config default (a [`StaticSession`] resolving one configured agent plus
+//! a `DeclarativeBrain` factory) is built by `AppState::new` and powers the
+//! playground and `--config agent.yaml`. A platform with its own control plane
+//! injects its own session and per-call `BrainFactory` via `AppState::with_parts`,
+//! reusing the same router, media WebSocket, and live-events WS with no fork of the
+//! axum bootstrap.
 
 pub mod config;
 pub mod run;
@@ -32,3 +43,6 @@ pub mod webrtc;
 
 pub use config::{ConfigError, ServerConfig, TopologyConfig};
 pub use session::StaticSession;
+
+#[cfg(feature = "server")]
+pub use server::{build_router, AppState, BrainFactory};

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -47,3 +47,6 @@ pub use session::StaticSession;
 
 #[cfg(feature = "server")]
 pub use server::{build_router, AppState, BrainFactory};
+
+#[cfg(feature = "webrtc")]
+pub use webrtc::{handle_offer, OfferParams};

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -42,6 +42,7 @@ pub mod events;
 pub mod webrtc;
 
 pub use config::{ConfigError, ServerConfig, TopologyConfig};
+pub use run::{env_spec_resolver, run_call, run_call_with, SpecResolver};
 pub use session::StaticSession;
 
 #[cfg(feature = "server")]

--- a/flowcat-server/src/run.rs
+++ b/flowcat-server/src/run.rs
@@ -89,7 +89,9 @@ pub fn env_spec_resolver(spec: &ProviderSpec) -> Result<ProviderSpec, FlowcatErr
 
 /// The provider specs a call runs with, after resolution — what the factory builds
 /// from. Realtime is a single spec; cascaded is the STT/LLM/TTS trio.
-#[derive(Debug)]
+///
+/// Deliberately not `Debug`: the specs carry resolved `api_key`s, so there is no
+/// derive to accidentally log a secret through.
 enum ResolvedProviders {
     Realtime(ProviderSpec),
     Cascaded {
@@ -337,14 +339,19 @@ mod tests {
             tts: cfg_spec("cartesia", "voice-xyz"),
         };
         // A resolver that fails for one leg (e.g. a missing secret) aborts cleanly.
-        let err = resolve_providers(&topology, |spec: &ProviderSpec| {
+        // (Matched out rather than `unwrap_err`'d so `ResolvedProviders` need not be
+        // `Debug` — it carries resolved api keys.)
+        let result = resolve_providers(&topology, |spec: &ProviderSpec| {
             if spec.provider == "openai" {
                 Err(FlowcatError::Other("no secret for openai".into()))
             } else {
                 Ok(spec.clone())
             }
-        })
-        .unwrap_err();
+        });
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected the resolver error to propagate"),
+        };
         assert!(err.to_string().contains("no secret for openai"));
     }
 }

--- a/flowcat-server/src/run.rs
+++ b/flowcat-server/src/run.rs
@@ -7,14 +7,20 @@
 //!   `build_s2s_task` (e.g. Gemini Live).
 //! - **Cascaded:** build STT/LLM/TTS via the factory and run `build_cascaded_call`.
 //!
-//! Provider **API keys are resolved from the environment** here (never from the
-//! config file or a per-call payload): `<PROVIDER>_API_KEY`, then
-//! `FLOWCAT_<PROVIDER>_API_KEY`, plus the well-known `GOOGLE_API_KEY` for the
-//! Gemini family.
+//! ## Who resolves provider keys
+//!
+//! [`run_call`] is the standalone-server default: it resolves provider **API keys
+//! from the environment** (never the config file or a per-call payload) via
+//! [`env_spec_resolver`] — `<PROVIDER>_API_KEY`, then `FLOWCAT_<PROVIDER>_API_KEY`,
+//! plus the well-known `GOOGLE_API_KEY` for the Gemini family.
+//!
+//! A platform with its **own** secret store / per-call provider selection calls
+//! [`run_call_with`] instead and supplies a [`SpecResolver`] — a
+//! `Fn(&ProviderSpec) -> Result<ProviderSpec>` that fills each leg's key (and may
+//! swap provider/model/options) from wherever it likes, with **no env reads** on
+//! that path. `run_call` is just `run_call_with` + [`env_spec_resolver`].
 
 use std::sync::Arc;
-
-use serde_json::{Map, Value};
 
 use flowcat_core::observer::FrameObserver;
 use flowcat_core::pipeline::CascadedConfig;
@@ -22,6 +28,16 @@ use flowcat_core::{AgentBrain, FlowcatError, MediaTransport, SessionSource};
 use flowcat_services::factory::{self, ProviderSpec};
 
 use crate::config::TopologyConfig;
+
+/// Resolves a call leg's final [`ProviderSpec`] (notably its `api_key`) from the
+/// "bare" spec the [`TopologyConfig`] implies.
+///
+/// The standalone server uses [`env_spec_resolver`] (keys from the process env); an
+/// embedder supplies its own — a secret-store lookup, a per-call config, etc. —
+/// shared across calls behind an `Arc`. Returning a full `ProviderSpec` (not just a
+/// key) lets a resolver also override provider/model/options per call.
+pub type SpecResolver =
+    Arc<dyn Fn(&ProviderSpec) -> Result<ProviderSpec, FlowcatError> + Send + Sync>;
 
 /// The ordered environment-variable names checked for `provider`'s API key.
 ///
@@ -61,31 +77,68 @@ pub fn key_from_env(provider: &str) -> String {
     String::new()
 }
 
-/// Build a [`ProviderSpec`] from a provider name + model + options, injecting the
-/// API key from the environment.
-fn spec_with_env_key(provider: &str, model: &str, options: Map<String, Value>) -> ProviderSpec {
-    ProviderSpec {
-        provider: provider.to_string(),
-        model: model.to_string(),
-        api_key: key_from_env(provider),
-        options,
-    }
-}
-
-/// Fill a config [`ProviderSpec`]'s `api_key` from the environment if it's empty
-/// (the config file never carries keys).
-fn enrich(spec: &ProviderSpec) -> ProviderSpec {
+/// The default [`SpecResolver`]: fill a leg's `api_key` from the environment if it's
+/// empty (the config file never carries keys). A non-empty key is left untouched.
+pub fn env_spec_resolver(spec: &ProviderSpec) -> Result<ProviderSpec, FlowcatError> {
     let mut s = spec.clone();
     if s.api_key.trim().is_empty() {
         s.api_key = key_from_env(&s.provider);
     }
-    s
+    Ok(s)
 }
 
-/// Assemble + run one call over `transport` per the resolved [`TopologyConfig`].
+/// The provider specs a call runs with, after resolution — what the factory builds
+/// from. Realtime is a single spec; cascaded is the STT/LLM/TTS trio.
+#[derive(Debug)]
+enum ResolvedProviders {
+    Realtime(ProviderSpec),
+    Cascaded {
+        stt: ProviderSpec,
+        llm: ProviderSpec,
+        tts: ProviderSpec,
+    },
+}
+
+/// Turn a [`TopologyConfig`] into the per-leg [`ProviderSpec`]s by running each leg
+/// through `resolve`. Realtime starts from a **bare** spec (empty key) built from
+/// the topology's provider/model/options; cascaded passes the config's specs (whose
+/// keys are always empty — the file never carries them). Factored out so the
+/// resolver wiring is unit-testable without a live provider connect.
+fn resolve_providers<R>(
+    topology: &TopologyConfig,
+    resolve: R,
+) -> Result<ResolvedProviders, FlowcatError>
+where
+    R: Fn(&ProviderSpec) -> Result<ProviderSpec, FlowcatError>,
+{
+    match topology {
+        TopologyConfig::Realtime {
+            provider,
+            model,
+            options,
+        } => {
+            let bare = ProviderSpec {
+                provider: provider.clone(),
+                model: model.clone(),
+                api_key: String::new(),
+                options: options.clone(),
+            };
+            Ok(ResolvedProviders::Realtime(resolve(&bare)?))
+        }
+        TopologyConfig::Cascaded { stt, llm, tts } => Ok(ResolvedProviders::Cascaded {
+            stt: resolve(stt)?,
+            llm: resolve(llm)?,
+            tts: resolve(tts)?,
+        }),
+    }
+}
+
+/// Assemble + run one call over `transport` per the resolved [`TopologyConfig`],
+/// resolving provider API keys **from the environment** ([`env_spec_resolver`]).
 ///
-/// The realtime/cascaded providers are built from the topology (keys from env);
-/// the pipeline runs to completion (returns when the call ends or errors).
+/// This is the standalone-server default; an embedder with its own secret store
+/// uses [`run_call_with`] to supply a [`SpecResolver`] instead. The pipeline runs
+/// to completion (returns when the call ends or errors).
 pub async fn run_call<T, B, S>(
     transport: T,
     topology: &TopologyConfig,
@@ -100,31 +153,54 @@ where
     B: AgentBrain + 'static,
     S: SessionSource + 'static,
 {
-    match topology {
-        TopologyConfig::Realtime {
-            provider,
-            model,
-            options,
-        } => {
-            let spec = spec_with_env_key(provider, model, options.clone());
+    run_call_with(
+        transport,
+        topology,
+        env_spec_resolver,
+        brain,
+        session,
+        run_id,
+        token,
+        observers,
+    )
+    .await
+}
+
+/// [`run_call`] with an embedder-supplied [`SpecResolver`]: each provider leg's
+/// final [`ProviderSpec`] comes from `resolve` (a secret store, per-call config, …)
+/// rather than the environment, so a platform reuses flowcat-server's orchestration
+/// without adopting its env convention. **No env reads happen on this path** unless
+/// `resolve` makes them itself.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_call_with<T, B, S, R>(
+    transport: T,
+    topology: &TopologyConfig,
+    resolve: R,
+    brain: B,
+    session: S,
+    run_id: i64,
+    token: String,
+    observers: Vec<Arc<dyn FrameObserver>>,
+) -> Result<(), FlowcatError>
+where
+    T: MediaTransport + 'static,
+    B: AgentBrain + 'static,
+    S: SessionSource + 'static,
+    R: Fn(&ProviderSpec) -> Result<ProviderSpec, FlowcatError>,
+{
+    match resolve_providers(topology, resolve)? {
+        ResolvedProviders::Realtime(spec) => {
+            let model = spec.model.clone();
             let realtime = factory::realtime(&spec)?;
             flowcat_core::pipeline::s2s::build_s2s_task_with_observers(
-                transport,
-                realtime,
-                brain,
-                session,
-                run_id,
-                token,
-                model.clone(),
-                observers,
+                transport, realtime, brain, session, run_id, token, model, observers,
             )
             .await?
             .run()
             .await
         }
-        TopologyConfig::Cascaded { stt, llm, tts } => {
-            let (stt_svc, llm_svc, tts_svc) =
-                factory::cascaded(&enrich(stt), &enrich(llm), &enrich(tts))?;
+        ResolvedProviders::Cascaded { stt, llm, tts } => {
+            let (stt_svc, llm_svc, tts_svc) = factory::cascaded(&stt, &llm, &tts)?;
             let config = CascadedConfig {
                 system_prompt: Some(brain.system_prompt()),
                 ..Default::default()
@@ -176,5 +252,99 @@ mod tests {
         let names = key_env_var_names("deepgram");
         assert!(!names.iter().any(|n| n == "GOOGLE_API_KEY"));
         assert_eq!(names[0], "DEEPGRAM_API_KEY");
+    }
+
+    // --- Provider/spec resolution (the #21 embedder seam). ----------------------
+
+    fn cfg_spec(provider: &str, model: &str) -> ProviderSpec {
+        ProviderSpec {
+            provider: provider.into(),
+            model: model.into(),
+            api_key: String::new(),
+            options: Default::default(),
+        }
+    }
+
+    #[test]
+    fn env_spec_resolver_leaves_a_preset_key_untouched() {
+        // A spec that already carries a key is passed through verbatim — the env is
+        // never consulted (so an embedder that pre-fills keys gets no env reads).
+        let spec = ProviderSpec {
+            api_key: "preset-key".into(),
+            ..cfg_spec("deepgram", "nova-3")
+        };
+        let out = env_spec_resolver(&spec).unwrap();
+        assert_eq!(out.api_key, "preset-key");
+        assert_eq!(out.provider, "deepgram");
+    }
+
+    #[test]
+    fn resolve_providers_realtime_uses_the_supplied_resolver() {
+        let topology = TopologyConfig::Realtime {
+            provider: "gemini".into(),
+            model: "gemini-2.0-flash".into(),
+            options: Default::default(),
+        };
+        // A custom resolver standing in for an embedder secret store — no env reads.
+        let resolved = resolve_providers(&topology, |spec: &ProviderSpec| {
+            assert!(spec.api_key.is_empty(), "realtime starts from a bare spec");
+            Ok(ProviderSpec {
+                api_key: "from-store".into(),
+                ..spec.clone()
+            })
+        })
+        .unwrap();
+        match resolved {
+            ResolvedProviders::Realtime(spec) => {
+                assert_eq!(spec.provider, "gemini");
+                assert_eq!(spec.model, "gemini-2.0-flash");
+                assert_eq!(spec.api_key, "from-store");
+            }
+            _ => panic!("expected realtime"),
+        }
+    }
+
+    #[test]
+    fn resolve_providers_cascaded_resolves_every_leg() {
+        let topology = TopologyConfig::Cascaded {
+            stt: cfg_spec("deepgram", "nova-3"),
+            llm: cfg_spec("openai", "gpt-4o"),
+            tts: cfg_spec("cartesia", "voice-xyz"),
+        };
+        // Resolver keys each leg from its provider name (embedder-owned, no env).
+        let resolved = resolve_providers(&topology, |spec: &ProviderSpec| {
+            Ok(ProviderSpec {
+                api_key: format!("{}-key", spec.provider),
+                ..spec.clone()
+            })
+        })
+        .unwrap();
+        match resolved {
+            ResolvedProviders::Cascaded { stt, llm, tts } => {
+                assert_eq!(stt.api_key, "deepgram-key");
+                assert_eq!(llm.api_key, "openai-key");
+                assert_eq!(tts.api_key, "cartesia-key");
+            }
+            _ => panic!("expected cascaded"),
+        }
+    }
+
+    #[test]
+    fn resolve_providers_propagates_a_resolver_error() {
+        let topology = TopologyConfig::Cascaded {
+            stt: cfg_spec("deepgram", "nova-3"),
+            llm: cfg_spec("openai", "gpt-4o"),
+            tts: cfg_spec("cartesia", "voice-xyz"),
+        };
+        // A resolver that fails for one leg (e.g. a missing secret) aborts cleanly.
+        let err = resolve_providers(&topology, |spec: &ProviderSpec| {
+            if spec.provider == "openai" {
+                Err(FlowcatError::Other("no secret for openai".into()))
+            } else {
+                Ok(spec.clone())
+            }
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("no secret for openai"));
     }
 }

--- a/flowcat-server/src/server.rs
+++ b/flowcat-server/src/server.rs
@@ -22,7 +22,7 @@ use flowcat_core::{
 };
 
 use crate::config::{ServerConfig, TopologyConfig};
-use crate::run;
+use crate::run::{self, SpecResolver};
 use crate::session::StaticSession;
 use crate::socket::AxumWsSocket;
 
@@ -48,6 +48,9 @@ pub struct AppState<S, B> {
     pub(crate) session: Arc<S>,
     pub(crate) brain_factory: BrainFactory<B>,
     pub(crate) topology: Arc<TopologyConfig>,
+    /// Resolves each call's provider specs (keys). Defaults to the env resolver;
+    /// an embedder overrides it via [`AppState::with_spec_resolver`].
+    pub(crate) spec_resolver: SpecResolver,
     pub(crate) public_url: Arc<Option<String>>,
     /// Per-call live-event channels for the WebRTC playground.
     #[cfg(feature = "webrtc")]
@@ -69,6 +72,7 @@ impl<S, B> Clone for AppState<S, B> {
             session: Arc::clone(&self.session),
             brain_factory: Arc::clone(&self.brain_factory),
             topology: Arc::clone(&self.topology),
+            spec_resolver: Arc::clone(&self.spec_resolver),
             public_url: Arc::clone(&self.public_url),
             #[cfg(feature = "webrtc")]
             events: Arc::clone(&self.events),
@@ -95,6 +99,9 @@ impl<S, B> AppState<S, B> {
             session,
             brain_factory,
             topology: Arc::new(topology),
+            // Default: resolve provider keys from the env (the standalone-server
+            // convention). An embedder swaps in its own via `with_spec_resolver`.
+            spec_resolver: Arc::new(run::env_spec_resolver),
             public_url: Arc::new(public_url),
             #[cfg(feature = "webrtc")]
             events: Arc::new(crate::events::EventRegistry::new()),
@@ -103,6 +110,14 @@ impl<S, B> AppState<S, B> {
             #[cfg(feature = "webrtc")]
             webrtc_bind_ip: webrtc_bind_ip_from_env(),
         }
+    }
+
+    /// Override how provider specs (API keys) are resolved per call — a platform
+    /// passes its own secret-store lookup so no provider key is read from the
+    /// process env on the call path. Defaults to [`run::env_spec_resolver`].
+    pub fn with_spec_resolver(mut self, resolver: SpecResolver) -> Self {
+        self.spec_resolver = resolver;
+        self
     }
 }
 
@@ -231,13 +246,24 @@ where
     let token = q.token;
     let session = Arc::clone(&state.session);
     let topology = Arc::clone(&state.topology);
+    let resolver = Arc::clone(&state.spec_resolver);
     info!(run_id, "plivo media ws upgrading");
     ws.on_upgrade(move |socket| async move {
         let transport = WsCarrierTransport::new(
             AxumWsSocket::new(socket),
             PlivoSerializer::new(CARRIER_RATE),
         );
-        let res = run::run_call(transport, &topology, brain, session, run_id, token, vec![]).await;
+        let res = run::run_call_with(
+            transport,
+            &topology,
+            &*resolver,
+            brain,
+            session,
+            run_id,
+            token,
+            vec![],
+        )
+        .await;
         match res {
             Ok(()) => info!(run_id, "plivo call ended cleanly"),
             Err(e) => error!(run_id, error = %e, "plivo call ended with error"),

--- a/flowcat-server/src/server.rs
+++ b/flowcat-server/src/server.rs
@@ -17,7 +17,9 @@ use serde_json::{json, Value};
 use tracing::{error, info, warn};
 
 use flowcat_agent::DeclarativeBrain;
-use flowcat_core::{PlivoSerializer, WsCarrierTransport};
+use flowcat_core::{
+    AgentBrain, FlowcatError, PlivoSerializer, ResolvedCall, SessionSource, WsCarrierTransport,
+};
 
 use crate::config::{ServerConfig, TopologyConfig};
 use crate::run;
@@ -27,12 +29,25 @@ use crate::socket::AxumWsSocket;
 /// Telephony carrier μ-law @ 8 kHz (the Plivo WS media format).
 const CARRIER_RATE: u32 = 8_000;
 
-/// Shared handler state: the resolved config + the agent graph (resolved once at
-/// startup) + this host's public base URL (for the Plivo answer XML).
-#[derive(Clone)]
-pub struct AppState {
-    pub(crate) config: Arc<ServerConfig>,
-    pub(crate) graph: Arc<Value>,
+/// Per-call brain constructor: builds a fresh [`AgentBrain`] from the
+/// [`ResolvedCall`] a [`SessionSource`] returns. The brain is per-call (it carries
+/// the run's conversation state), so an embedder supplies a factory rather than a
+/// single brain instance — the default wiring's factory builds a
+/// [`DeclarativeBrain`] from the resolved graph spec.
+pub type BrainFactory<B> = Arc<dyn Fn(&ResolvedCall) -> Result<B, FlowcatError> + Send + Sync>;
+
+/// Shared handler state for the HTTP + transport surface.
+///
+/// Generic over the embedder's [`SessionSource`] `S` and [`AgentBrain`] `B`: it
+/// holds **one** shared session (cloned cheaply per call) plus a per-call
+/// [`BrainFactory`], the pipeline [`TopologyConfig`], and this host's public base
+/// URL (for the Plivo answer XML). The zero-config default — [`StaticSession`] +
+/// [`DeclarativeBrain`] for the playground and `--config agent.yaml` — is built by
+/// [`AppState::new`]; an embedder injects its own pair via [`AppState::with_parts`].
+pub struct AppState<S, B> {
+    pub(crate) session: Arc<S>,
+    pub(crate) brain_factory: BrainFactory<B>,
+    pub(crate) topology: Arc<TopologyConfig>,
     pub(crate) public_url: Arc<Option<String>>,
     /// Per-call live-event channels for the WebRTC playground.
     #[cfg(feature = "webrtc")]
@@ -46,12 +61,40 @@ pub struct AppState {
     pub(crate) webrtc_bind_ip: std::net::Ipv4Addr,
 }
 
-impl AppState {
-    /// Build the shared state from a loaded config + its resolved graph spec.
-    pub fn new(config: ServerConfig, graph: Value, public_url: Option<String>) -> Self {
+// Hand-written so the bound is on the `Arc`s we actually hold, not on `S`/`B`
+// (a derive would wrongly require `S: Clone, B: Clone`).
+impl<S, B> Clone for AppState<S, B> {
+    fn clone(&self) -> Self {
         Self {
-            config: Arc::new(config),
-            graph: Arc::new(graph),
+            session: Arc::clone(&self.session),
+            brain_factory: Arc::clone(&self.brain_factory),
+            topology: Arc::clone(&self.topology),
+            public_url: Arc::clone(&self.public_url),
+            #[cfg(feature = "webrtc")]
+            events: Arc::clone(&self.events),
+            #[cfg(feature = "webrtc")]
+            next_pc: Arc::clone(&self.next_pc),
+            #[cfg(feature = "webrtc")]
+            webrtc_bind_ip: self.webrtc_bind_ip,
+        }
+    }
+}
+
+impl<S, B> AppState<S, B> {
+    /// Build the shared state from an embedder-supplied session + per-call brain
+    /// factory + pipeline topology. This is the injection point a platform uses to
+    /// run flowcat-server's HTTP/transport surface with its own control plane; the
+    /// playground/binary default is [`AppState::new`].
+    pub fn with_parts(
+        session: Arc<S>,
+        brain_factory: BrainFactory<B>,
+        topology: TopologyConfig,
+        public_url: Option<String>,
+    ) -> Self {
+        Self {
+            session,
+            brain_factory,
+            topology: Arc::new(topology),
             public_url: Arc::new(public_url),
             #[cfg(feature = "webrtc")]
             events: Arc::new(crate::events::EventRegistry::new()),
@@ -60,6 +103,27 @@ impl AppState {
             #[cfg(feature = "webrtc")]
             webrtc_bind_ip: webrtc_bind_ip_from_env(),
         }
+    }
+}
+
+impl AppState<StaticSession, DeclarativeBrain> {
+    /// Build the **default** shared state — [`StaticSession`] + [`DeclarativeBrain`]
+    /// — from a loaded config + its resolved graph spec. The session serves the one
+    /// configured agent (no control plane); the brain factory builds a declarative
+    /// brain from the resolved graph for each call.
+    pub fn new(config: ServerConfig, graph: Value, public_url: Option<String>) -> Self {
+        let ServerConfig {
+            agent,
+            topology,
+            transport,
+            ..
+        } = config;
+        let session = Arc::new(StaticSession::new(graph, agent.seed_vars, transport.kind));
+        let brain_factory: BrainFactory<DeclarativeBrain> = Arc::new(|resolved: &ResolvedCall| {
+            DeclarativeBrain::from_config(&resolved.brain_config)
+                .map_err(|e| FlowcatError::Other(format!("invalid agent graph: {e}")))
+        });
+        Self::with_parts(session, brain_factory, topology, public_url)
     }
 }
 
@@ -74,18 +138,35 @@ fn webrtc_bind_ip_from_env() -> std::net::Ipv4Addr {
 }
 
 /// Assemble the axum router over the shared [`AppState`].
-pub fn build_router(state: AppState) -> Router {
+///
+/// Generic over the embedder's session + brain types so the **same** router,
+/// `media_ws`, and events WS serve the default playground wiring and any injected
+/// [`SessionSource`] + [`AgentBrain`] pair alike.
+pub fn build_router<S, B>(state: AppState<S, B>) -> Router
+where
+    S: SessionSource + 'static,
+    B: AgentBrain + 'static,
+{
     let router = Router::new()
         .route("/healthz", get(healthz))
-        .route("/readyz", get(readyz))
-        .route("/telephony/ws/{provider}/{run_id}", get(media_ws))
-        .route("/telephony/answer/plivo/{run_id}", get(answer_plivo));
+        .route("/readyz", get(readyz::<S, B>))
+        .route("/telephony/ws/{provider}/{run_id}", get(media_ws::<S, B>))
+        .route(
+            "/telephony/answer/plivo/{run_id}",
+            get(answer_plivo::<S, B>),
+        );
     // The browser playground (page + WebRTC offer + live-events WS).
     #[cfg(feature = "webrtc")]
     let router = router
         .route("/", get(crate::webrtc::playground_page))
-        .route("/webrtc/offer", axum::routing::post(crate::webrtc::offer))
-        .route("/webrtc/events/{pc_id}", get(crate::events::events_ws));
+        .route(
+            "/webrtc/offer",
+            axum::routing::post(crate::webrtc::offer::<S, B>),
+        )
+        .route(
+            "/webrtc/events/{pc_id}",
+            get(crate::events::events_ws::<S, B>),
+        );
     router.with_state(state)
 }
 
@@ -93,8 +174,12 @@ async fn healthz() -> impl IntoResponse {
     axum::Json(json!({ "status": "ok" }))
 }
 
-async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
-    let ready = primary_provider_key_present(&state.config);
+async fn readyz<S, B>(State(state): State<AppState<S, B>>) -> impl IntoResponse
+where
+    S: SessionSource + 'static,
+    B: AgentBrain + 'static,
+{
+    let ready = primary_provider_key_present(&state.topology);
     let code = if ready {
         StatusCode::OK
     } else {
@@ -103,10 +188,10 @@ async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
     (code, axum::Json(json!({ "ready": ready })))
 }
 
-/// True iff the configured topology's primary provider has an API key in the env
-/// (realtime: the realtime provider; cascaded: the LLM leg).
-fn primary_provider_key_present(config: &ServerConfig) -> bool {
-    let provider = match &config.topology {
+/// True iff the topology's primary provider has an API key in the env (realtime:
+/// the realtime provider; cascaded: the LLM leg).
+fn primary_provider_key_present(topology: &TopologyConfig) -> bool {
+    let provider = match topology {
         TopologyConfig::Realtime { provider, .. } => provider.as_str(),
         TopologyConfig::Cascaded { llm, .. } => llm.provider.as_str(),
     };
@@ -120,53 +205,39 @@ struct TokenQuery {
 }
 
 /// `GET /telephony/ws/{provider}/{run_id}?token=` — the bidirectional Plivo media
-/// WS. The brain is built before the upgrade so a bad graph is a clean 422.
-async fn media_ws(
-    State(state): State<AppState>,
+/// WS. The call is resolved through the session and the brain built from it before
+/// the upgrade, so a bad resolve/graph is a clean error with no socket accepted.
+async fn media_ws<S, B>(
+    State(state): State<AppState<S, B>>,
     Path((provider, run_id)): Path<(String, i64)>,
     Query(q): Query<TokenQuery>,
     ws: WebSocketUpgrade,
-) -> Response {
+) -> Response
+where
+    S: SessionSource + 'static,
+    B: AgentBrain + 'static,
+{
     let provider = provider.to_ascii_lowercase();
     if provider != "plivo" {
         warn!(%provider, "media ws: only the 'plivo' carrier is served by this endpoint");
         return (StatusCode::NOT_FOUND, "unsupported carrier (only 'plivo')").into_response();
     }
 
-    let brain = match DeclarativeBrain::new(
-        state.graph.as_ref(),
-        Value::Object(Default::default()),
-        state.config.agent.seed_vars.clone(),
-    ) {
+    let brain = match resolve_brain(&state, run_id, &q.token).await {
         Ok(b) => b,
-        Err(e) => {
-            warn!(error = %e, "media ws: invalid agent graph");
-            return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
-        }
+        Err(r) => return r,
     };
 
     let token = q.token;
+    let session = Arc::clone(&state.session);
+    let topology = Arc::clone(&state.topology);
     info!(run_id, "plivo media ws upgrading");
     ws.on_upgrade(move |socket| async move {
         let transport = WsCarrierTransport::new(
             AxumWsSocket::new(socket),
             PlivoSerializer::new(CARRIER_RATE),
         );
-        let session = StaticSession::new(
-            (*state.graph).clone(),
-            state.config.agent.seed_vars.clone(),
-            "plivo",
-        );
-        let res = run::run_call(
-            transport,
-            &state.config.topology,
-            brain,
-            session,
-            run_id,
-            token,
-            vec![],
-        )
-        .await;
+        let res = run::run_call(transport, &topology, brain, session, run_id, token, vec![]).await;
         match res {
             Ok(()) => info!(run_id, "plivo call ended cleanly"),
             Err(e) => error!(run_id, error = %e, "plivo call ended with error"),
@@ -174,14 +245,50 @@ async fn media_ws(
     })
 }
 
+/// Resolve a call through the shared session and build its brain via the factory.
+///
+/// This is the per-call bootstrap shared by every transport (`media_ws` and the
+/// WebRTC playground): `resolve` lets a custom control-plane session pick the
+/// per-run graph (and reject an already-completed run), and the factory turns that
+/// resolved config into the brain. On any failure it returns the [`Response`] to
+/// send (the caller `?`-style early-returns it), so the socket/peer is never set up.
+pub(crate) async fn resolve_brain<S, B>(
+    state: &AppState<S, B>,
+    run_id: i64,
+    token: &str,
+) -> Result<B, Response>
+where
+    S: SessionSource,
+{
+    let resolved = match state.session.resolve(run_id, token).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(run_id, error = %e, "session resolve failed");
+            return Err((StatusCode::BAD_GATEWAY, e.to_string()).into_response());
+        }
+    };
+    if resolved.is_completed {
+        warn!(run_id, "run already completed; refusing to start");
+        return Err((StatusCode::CONFLICT, "run already completed").into_response());
+    }
+    (state.brain_factory)(&resolved).map_err(|e| {
+        warn!(run_id, error = %e, "brain factory rejected the resolved call");
+        (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response()
+    })
+}
+
 /// `GET /telephony/answer/plivo/{run_id}?token=` — the Plivo `<Stream>` answer XML
 /// pointing back at this host's media WS. Needs `FLOWCAT_PUBLIC_URL` to build a
 /// reachable `wss://` URL.
-async fn answer_plivo(
-    State(state): State<AppState>,
+async fn answer_plivo<S, B>(
+    State(state): State<AppState<S, B>>,
     Path(run_id): Path<i64>,
     Query(q): Query<TokenQuery>,
-) -> Response {
+) -> Response
+where
+    S: SessionSource + 'static,
+    B: AgentBrain + 'static,
+{
     let Some(public_base) = state.public_url.as_deref().filter(|s| !s.is_empty()) else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -200,7 +307,7 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt; // oneshot
 
-    fn test_state(public_url: Option<String>) -> AppState {
+    fn test_state(public_url: Option<String>) -> AppState<StaticSession, DeclarativeBrain> {
         let config = ServerConfig::parse(
             r#"{ "agent": { "graph_inline": {"nodes":[{"id":"s","type":"startCall"}],"edges":[]} },
                  "topology": { "mode": "realtime", "provider": "gemini" } }"#,
@@ -270,4 +377,165 @@ mod tests {
     // `oneshot` request — it would need a real WebSocket handshake. The provider
     // check itself is a simple string compare; the WS handshake path is covered by
     // an end-to-end call rather than a router unit test.
+
+    // --- Injectable framework: a custom SessionSource + AgentBrain in the SAME
+    // router/media_ws, with no StaticSession/DeclarativeBrain in sight. -----------
+
+    use async_trait::async_trait;
+    use flowcat_core::session::{Finalize, ToolDecl, UploadTarget};
+    use flowcat_core::types::BrainAction;
+    use serde_json::json;
+
+    /// A control-plane stand-in: `resolve` can fail, mark the run completed, or
+    /// return a per-run `brain_config` the brain factory reads.
+    struct FakeSession {
+        fail: bool,
+        completed: bool,
+        prompt: String,
+    }
+
+    #[async_trait]
+    impl SessionSource for FakeSession {
+        async fn resolve(&self, _run_id: i64, _token: &str) -> Result<ResolvedCall, FlowcatError> {
+            if self.fail {
+                return Err(FlowcatError::Session("control plane unreachable".into()));
+            }
+            Ok(ResolvedCall {
+                provider: "fake".into(),
+                brain_config: json!({ "prompt": self.prompt }),
+                is_completed: self.completed,
+            })
+        }
+        async fn complete(&self, _: i64, _: &str, _: Finalize) -> Result<(), FlowcatError> {
+            Ok(())
+        }
+        async fn artifact_upload_url(
+            &self,
+            _: i64,
+            _: &str,
+            _: &str,
+        ) -> Result<UploadTarget, FlowcatError> {
+            Err(FlowcatError::Session("no artifacts".into()))
+        }
+        async fn put_bytes(&self, _: &str, _: Vec<u8>, _: &str) -> Result<(), FlowcatError> {
+            Ok(())
+        }
+        async fn node_tools(
+            &self,
+            _: i64,
+            _: &str,
+            _: &str,
+        ) -> Result<Vec<ToolDecl>, FlowcatError> {
+            Ok(vec![])
+        }
+        async fn tool_call(
+            &self,
+            _: i64,
+            _: &str,
+            _: &str,
+            name: &str,
+            _: &Value,
+        ) -> Result<String, FlowcatError> {
+            Ok(name.to_string())
+        }
+    }
+
+    /// A hand-rolled brain (not the DeclarativeBrain) whose prompt is taken from the
+    /// resolved `brain_config`, so a test can prove the factory saw the session's
+    /// output.
+    #[derive(Debug)]
+    struct EchoBrain {
+        prompt: String,
+    }
+    impl AgentBrain for EchoBrain {
+        fn system_prompt(&self) -> String {
+            self.prompt.clone()
+        }
+        fn tools(&self) -> Vec<ToolDecl> {
+            vec![]
+        }
+        fn current_node_id(&self) -> String {
+            "echo".into()
+        }
+        fn on_tool_call(&mut self, _name: &str, _args: &Value) -> BrainAction {
+            BrainAction::Stay
+        }
+        fn is_finished(&self) -> bool {
+            false
+        }
+        fn collected_vars(&self) -> Value {
+            json!({})
+        }
+    }
+
+    fn fake_state(session: FakeSession) -> AppState<FakeSession, EchoBrain> {
+        let factory: BrainFactory<EchoBrain> = Arc::new(|resolved: &ResolvedCall| {
+            Ok(EchoBrain {
+                prompt: resolved.brain_config["prompt"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        });
+        let topology = TopologyConfig::Realtime {
+            provider: "gemini".into(),
+            model: String::new(),
+            options: Default::default(),
+        };
+        AppState::with_parts(Arc::new(session), factory, topology, None)
+    }
+
+    #[tokio::test]
+    async fn custom_session_and_brain_serve_the_same_router() {
+        // The whole point: build_router over an embedder's own pair, no fork.
+        let app = build_router(fake_state(FakeSession {
+            fail: false,
+            completed: false,
+            prompt: "hi from the control plane".into(),
+        }));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn resolve_brain_routes_through_the_injected_session() {
+        let state = fake_state(FakeSession {
+            fail: false,
+            completed: false,
+            prompt: "prompt-from-resolve".into(),
+        });
+        // resolve() → brain_config → factory: the brain reflects the session's output.
+        let brain = resolve_brain(&state, 1, "tok").await.expect("a brain");
+        assert_eq!(brain.system_prompt(), "prompt-from-resolve");
+    }
+
+    #[tokio::test]
+    async fn resolve_brain_rejects_an_already_completed_run() {
+        let state = fake_state(FakeSession {
+            fail: false,
+            completed: true,
+            prompt: "x".into(),
+        });
+        let resp = resolve_brain(&state, 1, "tok").await.unwrap_err();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn resolve_brain_surfaces_a_resolve_failure_as_bad_gateway() {
+        let state = fake_state(FakeSession {
+            fail: true,
+            completed: false,
+            prompt: "x".into(),
+        });
+        let resp = resolve_brain(&state, 1, "tok").await.unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
 }

--- a/flowcat-server/src/webrtc.rs
+++ b/flowcat-server/src/webrtc.rs
@@ -18,17 +18,15 @@ use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use tracing::{error, info, warn};
 
-use flowcat_agent::DeclarativeBrain;
 use flowcat_core::observer::{FrameObserver, RtviObserver, RtviSink};
+use flowcat_core::{AgentBrain, SessionSource};
 use flowcat_transports::WebRtcTransport;
 
 use crate::events::RtfSink;
 use crate::run;
-use crate::server::AppState;
-use crate::session::StaticSession;
+use crate::server::{resolve_brain, AppState};
 
 /// str0m carrier rate — matches the realtime input rate (the S2S processors
 /// resample to 16 kHz in / 24 kHz out internally).
@@ -60,19 +58,28 @@ pub async fn playground_page() -> Html<&'static str> {
 }
 
 /// `POST /webrtc/offer` — accept the browser SDP offer and run the configured agent.
-pub async fn offer(State(state): State<AppState>, Json(body): Json<OfferRequest>) -> Response {
-    // Build the brain from the configured graph BEFORE accepting the offer, so a
-    // bad graph is a clean 422 with no peer created.
-    let brain = match DeclarativeBrain::new(
-        state.graph.as_ref(),
-        Value::Object(Default::default()),
-        state.config.agent.seed_vars.clone(),
-    ) {
+///
+/// Generic over the embedder's session/brain: the call is resolved through the
+/// session and the brain built from it (via the shared [`resolve_brain`]) BEFORE a
+/// peer is created, so a bad resolve/graph is a clean error with no media bound.
+pub async fn offer<S, B>(
+    State(state): State<AppState<S, B>>,
+    Json(body): Json<OfferRequest>,
+) -> Response
+where
+    S: SessionSource + 'static,
+    B: AgentBrain + 'static,
+{
+    // The playground assigns the per-call id up front so `resolve` can key off it;
+    // the WebRTC path carries no carrier token.
+    let run_id = state.next_pc.fetch_add(1, Ordering::Relaxed) as i64;
+    let pc_id = format!("pc-{run_id}");
+
+    // Resolve + build the brain BEFORE accepting the offer, so a bad resolve/graph
+    // is a clean error with no peer created.
+    let brain = match resolve_brain(&state, run_id, "").await {
         Ok(b) => b,
-        Err(e) => {
-            warn!(error = %e, "webrtc offer: invalid agent graph");
-            return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
-        }
+        Err(r) => return r,
     };
 
     // Bind a UDP socket for the WebRTC media on the configured interface (str0m
@@ -100,21 +107,14 @@ pub async fn offer(State(state): State<AppState>, Json(body): Json<OfferRequest>
             }
         };
 
-    let run_id = state.next_pc.fetch_add(1, Ordering::Relaxed) as i64;
-    let pc_id = format!("pc-{run_id}");
-
     // Register the live-event channel BEFORE returning the answer so opening
     // markers aren't lost to a subscribe race.
     let (call_events, guard) = state.events.register(&pc_id);
     let sink: Arc<dyn RtviSink> = Arc::new(RtfSink::new(call_events));
     let observers: Vec<Arc<dyn FrameObserver>> = vec![Arc::new(RtviObserver::new(sink))];
 
-    let session = StaticSession::new(
-        (*state.graph).clone(),
-        state.config.agent.seed_vars.clone(),
-        "webrtc",
-    );
-    let topology = state.config.topology.clone();
+    let session = Arc::clone(&state.session);
+    let topology = Arc::clone(&state.topology);
     info!(pc_id = %pc_id, "webrtc offer accepted; running call detached");
     let call_pc = pc_id.clone();
     tokio::spawn(async move {
@@ -143,11 +143,13 @@ mod tests {
     use super::*;
     use crate::config::ServerConfig;
     use crate::server::{build_router, AppState};
+    use crate::session::StaticSession;
     use axum::body::Body;
     use axum::http::Request;
+    use flowcat_agent::DeclarativeBrain;
     use tower::ServiceExt;
 
-    fn state() -> AppState {
+    fn state() -> AppState<StaticSession, DeclarativeBrain> {
         let config = ServerConfig::parse(
             r#"{ "agent": { "graph_inline": {"nodes":[{"id":"s","type":"startCall","data":{"prompt":"hi"}},{"id":"e","type":"endCall"}],"edges":[{"id":"x","source":"s","target":"e","label":"done"}]} },
                  "topology": { "mode": "realtime", "provider": "gemini" } }"#,

--- a/flowcat-server/src/webrtc.rs
+++ b/flowcat-server/src/webrtc.rs
@@ -150,8 +150,16 @@ where
 /// `POST /webrtc/offer` — accept the browser SDP offer and run the configured agent.
 ///
 /// Generic over the embedder's session/brain: the call is resolved through the
-/// session and the brain built from it (via the shared [`resolve_brain`]) BEFORE a
+/// session and the brain built from it (via the shared `resolve_brain`) BEFORE a
 /// peer is created, so a bad resolve/graph is a clean error with no media bound.
+///
+/// This is flowcat-server's **own playground wrapper**: it mints the per-call
+/// `run_id` from an in-process counter and resolves with an empty token, which only
+/// makes sense for a control-plane-free session (the [`crate::session::StaticSession`]
+/// default). An embedder with a real control plane — whose session keys off a
+/// caller-supplied run id / token — should call [`handle_offer`] directly with those
+/// values rather than reuse this handler. (The carrier media-WS handler already
+/// takes the run id + token from the request and is the injectable seam there.)
 pub async fn offer<S, B>(
     State(state): State<AppState<S, B>>,
     Json(body): Json<OfferRequest>,

--- a/flowcat-server/src/webrtc.rs
+++ b/flowcat-server/src/webrtc.rs
@@ -9,7 +9,7 @@
 //! credentials in the page — the server runs the single configured agent and the
 //! browser is just a mic + speaker + transcript view.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -21,11 +21,12 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
 use flowcat_core::observer::{FrameObserver, RtviObserver, RtviSink};
-use flowcat_core::{AgentBrain, SessionSource};
+use flowcat_core::{AgentBrain, FlowcatError, SessionSource};
 use flowcat_transports::WebRtcTransport;
 
+use crate::config::TopologyConfig;
 use crate::events::RtfSink;
-use crate::run;
+use crate::run::{self, SpecResolver};
 use crate::server::{resolve_brain, AppState};
 
 /// str0m carrier rate — matches the realtime input rate (the S2S processors
@@ -57,6 +58,95 @@ pub async fn playground_page() -> Html<&'static str> {
     Html(PLAYGROUND_HTML)
 }
 
+/// Inputs for [`handle_offer`], grouped so the helper stays under the
+/// argument-count lint. Generic over the brain `B`, session `S`, and a `keepalive`
+/// value `G` the spawned call owns for its lifetime.
+pub struct OfferParams<B, S, G> {
+    /// The browser's SDP offer (post-ICE-gathering, so it carries candidates).
+    pub sdp: String,
+    /// Concrete IPv4 the media socket binds (str0m advertises it as the host ICE
+    /// candidate and rejects 0.0.0.0); the caller chooses the interface — security.
+    pub bind_ip: Ipv4Addr,
+    /// Pipeline-facing carrier sample rate the str0m transport resamples to.
+    pub carrier_rate: u32,
+    /// Which providers to run + how their specs (keys) resolve.
+    pub topology: TopologyConfig,
+    /// Resolves each provider leg's spec (see [`SpecResolver`]).
+    pub resolver: SpecResolver,
+    /// The conversation brain for this call.
+    pub brain: B,
+    /// The session bootstrap/finalize source.
+    pub session: S,
+    /// Run id passed to the pipeline.
+    pub run_id: i64,
+    /// Per-call token passed to the pipeline (empty for the playground).
+    pub token: String,
+    /// Pipeline observers (e.g. an `RtviObserver` bridging live events).
+    pub observers: Vec<Arc<dyn FrameObserver>>,
+    /// A value held by the spawned call and dropped when it ends (e.g. an events
+    /// channel drop-guard). Pass `()` if there is nothing to hold.
+    pub keepalive: G,
+}
+
+/// Accept a browser SDP **offer**, bind a media socket, build the str0m transport,
+/// spawn the call detached, and return the **SDP answer** to send back.
+///
+/// This is the reusable "browser offer → audio session" signaling primitive: it
+/// owns the offer/answer, the UDP bind, the str0m transport, and the call spawn —
+/// but NOT the HTTP request/response shapes or auth (the caller frames those).
+/// flowcat-server's own [`offer`] is a thin wrapper over it; an external server
+/// calls it the same way with its own session + brain.
+///
+/// Errors before the spawn surface to the caller: a bind failure is
+/// [`FlowcatError::Io`]; a malformed/unacceptable offer is [`FlowcatError::Protocol`]
+/// (or another transport error). The call itself runs detached — once the answer is
+/// returned, a call-time failure is logged, not returned.
+pub async fn handle_offer<B, S, G>(params: OfferParams<B, S, G>) -> Result<String, FlowcatError>
+where
+    B: AgentBrain + 'static,
+    S: SessionSource + 'static,
+    G: Send + 'static,
+{
+    let OfferParams {
+        sdp,
+        bind_ip,
+        carrier_rate,
+        topology,
+        resolver,
+        brain,
+        session,
+        run_id,
+        token,
+        observers,
+        keepalive,
+    } = params;
+
+    // Bind the media socket on the chosen interface (str0m advertises it as the
+    // host ICE candidate and rejects 0.0.0.0). An io error here is the caller's 5xx.
+    let bind = SocketAddr::new(IpAddr::V4(bind_ip), 0);
+    let socket = tokio::net::UdpSocket::bind(bind).await?;
+
+    // Accept the offer → the str0m transport + the SDP answer. A bad offer is an Err
+    // with no peer created.
+    let (transport, answer) = WebRtcTransport::accept_offer(&sdp, socket, carrier_rate)?;
+
+    // Run the call detached; the answer goes back to the browser now.
+    info!(run_id, "webrtc offer accepted; running call detached");
+    tokio::spawn(async move {
+        let _keepalive = keepalive; // held until call end (e.g. deregisters events)
+        let res = run::run_call_with(
+            transport, &topology, &*resolver, brain, session, run_id, token, observers,
+        )
+        .await;
+        match res {
+            Ok(()) => info!(run_id, "webrtc call ended cleanly"),
+            Err(e) => error!(run_id, error = %e, "webrtc call ended with error"),
+        }
+    });
+
+    Ok(answer)
+}
+
 /// `POST /webrtc/offer` — accept the browser SDP offer and run the configured agent.
 ///
 /// Generic over the embedder's session/brain: the call is resolved through the
@@ -82,60 +172,46 @@ where
         Err(r) => return r,
     };
 
-    // Bind a UDP socket for the WebRTC media on the configured interface (str0m
-    // advertises this as the host ICE candidate and rejects 0.0.0.0).
-    let bind = SocketAddr::new(IpAddr::V4(state.webrtc_bind_ip), 0);
-    let socket = match tokio::net::UdpSocket::bind(bind).await {
-        Ok(s) => s,
-        Err(e) => {
-            error!(error = %e, "webrtc offer: failed to bind UDP socket");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to bind a media socket",
-            )
-                .into_response();
-        }
-    };
-
-    // Accept the browser offer → the str0m transport + the SDP answer.
-    let (transport, answer) =
-        match WebRtcTransport::accept_offer(&body.sdp, socket, WEBRTC_CARRIER_RATE) {
-            Ok(pair) => pair,
-            Err(e) => {
-                warn!(error = %e, "webrtc offer: accept_offer failed");
-                return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
-            }
-        };
-
     // Register the live-event channel BEFORE returning the answer so opening
-    // markers aren't lost to a subscribe race.
+    // markers aren't lost to a subscribe race; the guard rides the call as its
+    // `keepalive` and deregisters the channel on call end.
     let (call_events, guard) = state.events.register(&pc_id);
     let sink: Arc<dyn RtviSink> = Arc::new(RtfSink::new(call_events));
     let observers: Vec<Arc<dyn FrameObserver>> = vec![Arc::new(RtviObserver::new(sink))];
 
-    let session = Arc::clone(&state.session);
-    let topology = Arc::clone(&state.topology);
-    info!(pc_id = %pc_id, "webrtc offer accepted; running call detached");
-    let call_pc = pc_id.clone();
-    tokio::spawn(async move {
-        let _guard = guard; // deregister the live-event channel on call end
-        let res = run::run_call(
-            transport,
-            &topology,
-            brain,
-            session,
-            run_id,
-            String::new(),
-            observers,
-        )
-        .await;
-        match res {
-            Ok(()) => info!(pc_id = %call_pc, "webrtc call ended cleanly"),
-            Err(e) => error!(pc_id = %call_pc, error = %e, "webrtc call ended with error"),
-        }
-    });
+    // The reusable signaling primitive owns the offer/answer + bind + transport +
+    // spawn; this handler only frames the HTTP request/response (and the events WS).
+    let answer = handle_offer(OfferParams {
+        sdp: body.sdp,
+        bind_ip: state.webrtc_bind_ip,
+        carrier_rate: WEBRTC_CARRIER_RATE,
+        topology: (*state.topology).clone(),
+        resolver: Arc::clone(&state.spec_resolver),
+        brain,
+        session: Arc::clone(&state.session),
+        run_id,
+        token: String::new(),
+        observers,
+        keepalive: guard,
+    })
+    .await;
 
-    Json(OfferResponse { sdp: answer, pc_id }).into_response()
+    match answer {
+        Ok(sdp) => Json(OfferResponse { sdp, pc_id }).into_response(),
+        // A bind failure is a server error; a bad/unacceptable offer is the client's.
+        Err(e @ FlowcatError::Io(_)) => {
+            error!(pc_id = %pc_id, error = %e, "webrtc offer: failed to bind media socket");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to bind a media socket",
+            )
+                .into_response()
+        }
+        Err(e) => {
+            warn!(pc_id = %pc_id, error = %e, "webrtc offer: rejected");
+            (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -194,7 +270,100 @@ mod tests {
             .await
             .unwrap();
         // A graph this small is valid, so we get past the brain build; the junk SDP
-        // fails str0m's accept_offer → 422 (client error), no peer created.
+        // fails str0m's accept_offer → 422 (client error), no peer created. (The
+        // handler now delegates to `handle_offer`, which surfaces the Protocol error
+        // it maps to 422.)
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // --- The reusable signaling helper, called directly (the external-server path). ---
+
+    /// A realistic (minimal) browser-style SDP offer negotiating Opus, with the ICE
+    /// + DTLS lines a real offer carries — close enough for str0m to accept it.
+    fn sample_browser_offer() -> String {
+        "v=0\r\n\
+         o=- 4611731400430051336 2 IN IP4 127.0.0.1\r\n\
+         s=-\r\n\
+         t=0 0\r\n\
+         a=group:BUNDLE 0\r\n\
+         a=msid-semantic: WMS\r\n\
+         m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n\
+         c=IN IP4 127.0.0.1\r\n\
+         a=rtcp:9 IN IP4 0.0.0.0\r\n\
+         a=ice-ufrag:F7gI\r\n\
+         a=ice-pwd:x9cml/YzichV2+XlhiMu8g\r\n\
+         a=ice-options:trickle\r\n\
+         a=fingerprint:sha-256 \
+         AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89\r\n\
+         a=setup:actpass\r\n\
+         a=mid:0\r\n\
+         a=sendrecv\r\n\
+         a=rtcp-mux\r\n\
+         a=rtpmap:111 opus/48000/2\r\n\
+         a=fmtp:111 minptime=10;useinbandfec=1\r\n"
+            .to_string()
+    }
+
+    /// Build the brain + session an external caller would hand the helper. The call
+    /// it spawns will fail to connect (no provider key) — fine, that's detached; the
+    /// signaling test only asserts on the returned SDP answer.
+    fn offer_params(sdp: String) -> OfferParams<DeclarativeBrain, StaticSession, ()> {
+        let graph = serde_json::json!({
+            "nodes": [{ "id": "s", "type": "startCall", "data": { "prompt": "hi" } }],
+            "edges": []
+        });
+        let brain =
+            DeclarativeBrain::new(&graph, serde_json::json!({}), Default::default()).unwrap();
+        let session = StaticSession::new(graph, Default::default(), "test");
+        OfferParams {
+            sdp,
+            bind_ip: std::net::Ipv4Addr::LOCALHOST,
+            carrier_rate: WEBRTC_CARRIER_RATE,
+            topology: TopologyConfig::Realtime {
+                provider: "gemini".into(),
+                model: String::new(),
+                options: Default::default(),
+            },
+            resolver: Arc::new(run::env_spec_resolver),
+            brain,
+            session,
+            run_id: 1,
+            token: String::new(),
+            observers: vec![],
+            keepalive: (),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_offer_accepts_a_browser_offer_and_returns_an_answer() {
+        // The external-server path: build the helper's inputs ourselves (no AppState)
+        // and get a valid SDP answer back — a working str0m audio session at the
+        // signaling boundary.
+        let answer = handle_offer(offer_params(sample_browser_offer()))
+            .await
+            .expect("a valid offer yields an answer");
+        assert!(answer.starts_with("v=0"), "answer is SDP: {answer}");
+        assert!(answer.contains("m=audio"), "answer has the audio m-line");
+        assert!(
+            answer.to_ascii_lowercase().contains("opus"),
+            "answer negotiates opus: {answer}"
+        );
+        assert!(
+            answer.contains("a=fingerprint:"),
+            "answer carries the DTLS-SRTP fingerprint"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_offer_rejects_a_malformed_offer() {
+        // Same helper, bad SDP → a clean Protocol error (no panic, no peer), which
+        // the HTTP wrapper maps to 422.
+        let err = handle_offer(offer_params("not-a-valid-sdp".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FlowcatError::Protocol(_)),
+            "malformed offer is a protocol error, got: {err:?}"
+        );
     }
 }


### PR DESCRIPTION
Makes `flowcat-server` a reusable framework component a platform composes, rather than a standalone-only binary — the LiveKit-core / LiveKit-Agents layering. Closes #20, #21, #22. The zero-config default (StaticSession + DeclarativeBrain, keys from env) is unchanged for the playground and `--config agent.yaml`.

Three logically-separate commits:

### #20 — HTTP/transport layer generic over `SessionSource` + `AgentBrain`
- `AppState<S, B>` holds one shared `Arc<S>` session + a per-call `BrainFactory<B>` (`Fn(&ResolvedCall) -> Result<B>`); `build_router`/`media_ws`/`offer`/`events_ws`/`readyz`/`answer_plivo` are generic.
- Every transport routes through `session.resolve()` → `ResolvedCall` → brain factory (clean error paths: resolve `502`, completed run `409`, bad graph `422`), so an embedder's own control plane drives the same router with no fork of the axum bootstrap.
- `AppState::new` keeps the default wiring; `AppState::with_parts` is the injection point.
- flowcat-core gains a blanket `impl SessionSource for Arc<T>` (`?Sized`) so a shared session is cloned per-call and passed by value into the pipeline builders.

### #21 — embedder-supplied provider/key resolution in `run_call`
- New `run_call_with(topology, resolver, …)` taking a `SpecResolver` (`Fn(&ProviderSpec) -> Result<ProviderSpec>`); `run_call` = `run_call_with` + `env_spec_resolver`, so the standalone server still reads keys from env. No env reads on the embedder path.
- Threaded through `AppState` (`with_spec_resolver`) so the injectable server uses a platform's own secret store.

### #22 — reusable WebRTC `handle_offer` signaling helper
- `handle_offer(OfferParams { … }) -> SDP answer` owns the offer/answer + UDP bind + str0m transport + detached call spawn (via `run_call_with`), but not the HTTP shapes/auth. A generic `keepalive` rides the call (playground passes its events drop-guard; an external caller passes `()`).
- `webrtc::offer` is now a thin wrapper over it.

### Verification
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings` (+ `--features server`/`webrtc`) clean.
- Full hermetic suite green; flowcat-server adds offline tests for a custom session+brain injected into the same router, the provider-resolver seam, and WebRTC signaling (valid offer → answer, malformed → clean error).
- **No `Cargo.toml`/`Cargo.lock` changes** — the default (no-feature) build pulls no new provider/network deps (golden rule).

One intentional behavior addition: `media_ws`/`offer` now call `session.resolve()` (the standalone server previously skipped it) and honor `ResolvedCall::is_completed` as a replay guard — a no-op for `StaticSession`, relevant only for a custom control-plane session.
