### PR TITLE
Fix lmnt + mistral TTS and one-shot audio truncation

### DIFF
--- a/flowcat-services/src/tts/lmnt.rs
+++ b/flowcat-services/src/tts/lmnt.rs
@@ -9,13 +9,16 @@
 //! ```text
 //! POST https://api.lmnt.com/v1/ai/speech/bytes
 //!   X-API-Key: <key>
-//!   { "text": "...", "voice": "...", "format": "raw", "sample_rate": 24000,
+//!   { "text": "...", "voice": "...", "format": "wav", "sample_rate": 24000,
 //!     "model": "aurora", "language": "en" }
 //! ```
 //!
-//! With `format: "raw"` the response body is headerless little-endian s16 PCM at
-//! the requested sample rate. [`build_payload`] / [`LmntTts::url`] are the **pure**
-//! seam.
+//! With `format: "wav"` the response body is a 16-bit little-endian PCM WAV at the
+//! requested sample rate (LMNT streams it with placeholder `0xFFFFFFFF` chunk
+//! sizes); [`strip_wav_header`](tail::strip_wav_header) extracts the s16 data. The
+//! `"raw"` format is avoided because it returns 32-bit float PCM
+//! (`application/vnd.lmnt.audio-fp32`), which the s16 framer would misread.
+//! [`build_payload`] / [`LmntTts::url`] are the **pure** seam.
 
 use std::sync::Arc;
 
@@ -85,13 +88,16 @@ impl LmntTts {
     }
 }
 
-/// Build the LMNT synthesis JSON body (pure — the request seam). `format: "raw"`
-/// requests headerless little-endian s16 PCM.
+/// Build the LMNT synthesis JSON body (pure — the request seam). `format: "wav"`
+/// requests a 16-bit little-endian PCM WAV at the chosen sample rate. (LMNT's
+/// `"raw"` format returns 32-bit float PCM — `application/vnd.lmnt.audio-fp32` —
+/// which the s16 framer would misread as buzz, so we take the WAV and strip its
+/// header.)
 fn build_payload(text: &str, voice: &str, sample_rate: u32, model: &str, lang: &str) -> Value {
     json!({
         "text": text,
         "voice": voice,
-        "format": "raw",
+        "format": "wav",
         "sample_rate": sample_rate,
         "model": model,
         "language": lang,
@@ -140,7 +146,7 @@ impl TtsService for LmntTts {
             .bytes()
             .await
             .map_err(|e| FlowcatError::Network(format!("lmnt body: {e}")))?;
-        // `format: raw` is headerless PCM, but tolerate a WAV body defensively.
+        // `format: wav` returns a 16-bit PCM WAV; strip the header to raw s16 PCM.
         let pcm = tail::strip_wav_header(&bytes);
         Ok(tail::one_shot_frames(pcm, self.sample_rate, context_id))
     }
@@ -155,7 +161,7 @@ mod tests {
         let p = build_payload("hi", "voice-x", 24_000, "aurora", "en");
         assert_eq!(p["text"], "hi");
         assert_eq!(p["voice"], "voice-x");
-        assert_eq!(p["format"], "raw");
+        assert_eq!(p["format"], "wav");
         assert_eq!(p["sample_rate"], 24_000);
         assert_eq!(p["model"], "aurora");
         assert_eq!(p["language"], "en");

--- a/flowcat-services/src/tts/mistral.rs
+++ b/flowcat-services/src/tts/mistral.rs
@@ -116,10 +116,15 @@ pub fn build_body(text: &str, model: &str, voice: &str) -> Value {
 }
 
 /// Decode the Mistral SSE response body into PCM samples (pure seam). Each
-/// `data:` line is JSON; a `speech.audio.delta` event's `data.audio_data` is
-/// base64 float32 PCM, concatenated in order and converted to i16. Non-`data`
-/// lines, the `[DONE]` sentinel, malformed JSON, or other event types are skipped
-/// — never panics.
+/// `data:` line is JSON; a `speech.audio.delta` event carries base64 float32 PCM
+/// in `audio_data`, concatenated in order and converted to i16. Non-`data` lines,
+/// the `[DONE]` sentinel, malformed JSON, or other event types are skipped — never
+/// panics.
+///
+/// The live API tags the event kind on a top-level `type` field and puts
+/// `audio_data` at the top level (`{"type":"speech.audio.delta","audio_data":…}`);
+/// we also accept an `event` field and a nested `data.audio_data` so both shapes
+/// decode.
 pub fn decode_sse(body: &[u8]) -> Vec<i16> {
     let text = String::from_utf8_lossy(body);
     let mut pcm = Vec::new();
@@ -135,12 +140,16 @@ pub fn decode_sse(body: &[u8]) -> Vec<i16> {
         let Ok(value) = serde_json::from_str::<Value>(payload) else {
             continue;
         };
-        if value.get("event").and_then(|e| e.as_str()) != Some("speech.audio.delta") {
+        let kind = value
+            .get("type")
+            .or_else(|| value.get("event"))
+            .and_then(|e| e.as_str());
+        if kind != Some("speech.audio.delta") {
             continue;
         }
         if let Some(b64) = value
-            .get("data")
-            .and_then(|d| d.get("audio_data"))
+            .get("audio_data")
+            .or_else(|| value.get("data").and_then(|d| d.get("audio_data")))
             .and_then(|a| a.as_str())
         {
             let f32_bytes = base64_decode(b64);
@@ -172,11 +181,12 @@ mod tests {
         d2_bytes.extend_from_slice(&(-1.0f32).to_le_bytes());
         d2_bytes.extend_from_slice(&0.0f32.to_le_bytes());
         let d2 = http::base64_encode(&d2_bytes);
+        // Live wire format: top-level `type` + `audio_data`.
         let sse = format!(
             "data: {}\n\ndata: {}\n\ndata: {}\n\ndata: [DONE]\n",
-            json!({ "event": "speech.audio.delta", "data": { "audio_data": d1 } }),
-            json!({ "event": "speech.audio.delta", "data": { "audio_data": d2 } }),
-            json!({ "event": "speech.audio.done" }),
+            json!({ "type": "speech.audio.delta", "audio_data": d1 }),
+            json!({ "type": "speech.audio.delta", "audio_data": d2 }),
+            json!({ "type": "speech.audio.done" }),
         );
         assert_eq!(decode_sse(sse.as_bytes()), vec![32767, -32767, 0]);
     }

--- a/flowcat-services/src/tts/tail_tts_common.rs
+++ b/flowcat-services/src/tts/tail_tts_common.rs
@@ -67,15 +67,26 @@ pub fn pcm_audio_frame(bytes: &[u8], rate: u32, context_id: &Arc<str>) -> Option
     })
 }
 
-/// Frame a one-shot synthesis (`TtsStarted` → [one `TtsAudio`] → `TtsStopped`).
+/// Frame a one-shot synthesis (`TtsStarted` → [`TtsAudio`…] → `TtsStopped`).
 /// The single helper every HTTP/local provider's `run_tts` funnels through, so the
 /// framing is identical across the tail.
+///
+/// The whole-utterance PCM is split into ~20 ms `TtsAudio` frames, like the
+/// streaming providers and `http_tts_common::tts_frames` do. The transport paces
+/// realtime audio in small frames; a single giant frame for the whole utterance is
+/// mishandled (only its tail plays).
 pub fn one_shot_frames(pcm_bytes: &[u8], rate: u32, context_id: Arc<str>) -> Vec<Frame> {
-    let mut out = vec![Frame::TtsStarted {
+    let pcm = pcm_s16le(pcm_bytes);
+    let chunk = (rate as usize / 50).max(1); // ~20 ms at `rate`
+    let mut out = Vec::with_capacity(pcm.len() / chunk + 2);
+    out.push(Frame::TtsStarted {
         context_id: Some(context_id.clone()),
-    }];
-    if let Some(audio) = pcm_audio_frame(pcm_bytes, rate, &context_id) {
-        out.push(audio);
+    });
+    for samples in pcm.chunks(chunk) {
+        out.push(Frame::TtsAudio {
+            audio: Arc::new(AudioFrame::mono(samples.to_vec(), rate)),
+            context_id: Some(context_id.clone()),
+        });
     }
     out.push(Frame::TtsStopped {
         context_id: Some(context_id),
@@ -249,6 +260,30 @@ mod tail_common_tests {
         let ctx: Arc<str> = Arc::from("ctx-1");
         let frames = one_shot_frames(&[], 24_000, ctx);
         assert_eq!(frames.len(), 2); // started + stopped, no audio
+    }
+
+    #[test]
+    fn one_shot_frames_chunks_into_20ms_frames() {
+        let ctx: Arc<str> = Arc::from("ctx-1");
+        // 1 s of audio at 24 kHz = 24000 samples → 50 chunks of ≤480 samples
+        // (~20 ms each), bracketed by Started/Stopped.
+        let samples: Vec<i16> = (0..24_000).map(|i| (i % 1000) as i16).collect();
+        let bytes: Vec<u8> = samples.iter().flat_map(|s| s.to_le_bytes()).collect();
+        let frames = one_shot_frames(&bytes, 24_000, ctx);
+        assert!(matches!(frames[0], Frame::TtsStarted { .. }));
+        assert!(matches!(frames[frames.len() - 1], Frame::TtsStopped { .. }));
+        let audio: Vec<&_> = frames
+            .iter()
+            .filter_map(|f| match f {
+                Frame::TtsAudio { audio, .. } => Some(audio),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(audio.len(), 50, "1 s at 24 kHz should be 50 ~20 ms frames");
+        assert!(audio.iter().all(|a| a.pcm.len() <= 480));
+        // Reassembling the chunks reproduces the original PCM exactly.
+        let rejoined: Vec<i16> = audio.iter().flat_map(|a| a.pcm.clone()).collect();
+        assert_eq!(rejoined, samples);
     }
 
     #[test]


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
## What & why

Three TTS fixes found while testing connectors end-to-end:

- **lmnt buzzing** — `LmntTts` requested `format: "raw"`, but that returns
  32-bit float PCM (`application/vnd.lmnt.audio-fp32`), which the s16 framer
  read as a loud buzz. Switched to `format: "wav"` (16-bit PCM) and strip the
  header via the existing `strip_wav_header` path.
- **one-shot audio truncation** — `tail_tts_common::one_shot_frames` emitted the
  whole utterance as one big `TtsAudio` frame, so the transport only played its
  tail. It now chunks into ~20 ms frames, like `http_tts_common::tts_frames`
  already does. Fixes lmnt and the other tail connectors (kokoro, fish, smallest,
  piper, xtts, neuphonic, aws_polly, nvidia).
- **mistral silence** — the SSE decoder looked for an `event` field with
  `data.audio_data`, but the live API sends
  `{"type":"speech.audio.delta","audio_data":...}` (top-level `type` and
  `audio_data`), so every chunk was skipped. It now reads both shapes.

Closes #17
Closes #18
Closes #19

## Type of change

- [x] Bug fix
- [ ] New provider / transport / serializer
- [ ] New feature or processor
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] `cargo build` (default features) compiles and pulls **no** new networked
      dependency into the default build.
- [x] `cargo test` is green and **offline** (no test hits the network).
- [x] `cargo clippy --all-targets` is clean.
- [x] `cargo fmt --all` has been run.
- [x] Every new source file starts with the SPDX header
      `// SPDX-License-Identifier: Apache-2.0`.
- [ ] If a provider was added: it is `dep:`-gated behind its own Cargo feature,
      registered in the category `mod.rs` + the `*-all` umbrella, and covered by a
      fixture / known-answer test. `FEATURES.md` is updated.
- [ ] If a new dependency or third-party protocol was introduced: `NOTICE` is
      updated as needed.
- [x] The PR honestly states what is **fixture-tested** vs **live-verified**.

## Notes for reviewers

No new providers or dependencies — all three are fixes to existing connectors,
using helpers already in the tree. The new behavior is covered by updated unit
tests (`one_shot_frames` chunking; mistral SSE `type`/top-level `audio_data`;
lmnt `format: "wav"`). All three were also **live-verified** end-to-end over a
real WebRTC call (audible), in addition to the fixture tests.