### PR TITLE
Fix four broken STT/TTS connectors (camb, gradium, whisper_local, nvidia)

### DIFF
--- a/flowcat-services/Cargo.toml
+++ b/flowcat-services/Cargo.toml
@@ -56,7 +56,7 @@ stt-fal           = ["stt-openai"]                                          # (W
 stt-speaches      = ["stt-openai"]                                          # (W) Whisper-HTTP
 stt-xai           = ["stt-openai"]                                          # (W) Whisper-HTTP
 stt-google        = ["dep:tonic", "dep:tokio", "dep:bytes", "dep:http", "tonic/channel", "tonic/tls-aws-lc", "tonic/tls-webpki-roots"]  # (D) gRPC bidi (live transport)
-stt-nvidia        = ["dep:tonic", "dep:tokio"]                             # (D) gRPC (Riva)
+stt-nvidia        = ["dep:tonic", "dep:tokio", "dep:bytes", "dep:http", "tonic/channel", "tonic/tls-aws-lc", "tonic/tls-webpki-roots"]  # (D) gRPC bidi (live transport)
 stt-aws-transcribe = ["dep:reqwest", "dep:tokio-tungstenite", "dep:tokio", "dep:hmac", "dep:sha2"]  # (D) SigV4 WS
 stt-whisper-local = ["dep:whisper-rs"]                                      # (D) local (C build: cmake)
 # tts — see PROVIDERS.md §3. Streaming-WS carry tokio-tungstenite +

--- a/flowcat-services/src/stt/gradium.rs
+++ b/flowcat-services/src/stt/gradium.rs
@@ -2,84 +2,99 @@
 //
 //! **Gradium** streaming STT.
 //!
-//! A **(D)istinct** streaming-WebSocket client. Gradium is **not** present in the
-//! vendored pipecat sources, so (unlike the other providers in this group) there
-//! is no upstream class to cross-check against. This impl therefore targets
-//! Gradium's documented realtime shape: a single WSS endpoint authenticated with
-//! `Authorization: Bearer <api-key>`, raw little-endian PCM streamed as **binary**
-//! frames, and bare-JSON transcript messages:
+//! A **(D)istinct** streaming-WebSocket client for Gradium's realtime ASR
+//! (<https://docs.gradium.ai/api-reference/endpoint/stt-websocket>):
+//! connect to `wss://api.gradium.ai/api/speech/asr` with an `x-api-key` header,
+//! send a JSON **setup** message (model + input PCM format), then stream each
+//! audio chunk base64-encoded inside a JSON envelope
+//! `{ "type": "audio", "audio": "<base64 pcm_s16le>" }`.
 //!
-//! ```json
-//! { "type": "transcript", "text": "book a dentist", "is_final": true, "language": "en" }
-//! ```
-//!
-//! `is_final` true → final [`Frame::Transcription`]; otherwise interim. Any
-//! non-transcript / empty / malformed message yields nothing. The transport is
-//! the shared [`ws_stt`] seam; only the bare-JSON [`decode_message`] is
-//! Gradium-specific. The host/encoding are the documented defaults and the
-//! decode is the contract the wire-fixture tests pin — adjust the base URL via
-//! [`GradiumStt::base_url`] if Gradium's endpoint differs in a live deployment.
+//! The server returns transcribed segments as
+//! `{ "type": "text", "text": "hello world", "start_s": 0.5, "stream_id": 0 }`.
+//! Gradium streams these **per word/segment** and has **no per-message end-of-turn
+//! flag** (turn-taking is client-driven from VAD). Emitting one final transcript per
+//! `text` would split a single utterance into many turns, so instead each `text` is
+//! carried as an interim, accumulated, and the connector emits **one** final
+//! [`Frame::Transcription`] when transcription goes quiet for [`TURN_GAP_MS`] (the
+//! end-of-utterance boundary). The audio-chunk cadence is the logical clock — no VAD
+//! parsing or flush round-trip is needed because the segment text has already
+//! arrived. The transport is the shared [`ws_stt`] seam; the setup/audio encode and
+//! the bare-JSON [`decode_message`] are the Gradium-specific seams.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use flowcat_core::error::Result;
-use flowcat_core::processor::frame::{AudioFrame, Frame, Language, StartParams};
+use flowcat_core::processor::frame::{AudioFrame, Frame, StartParams};
 use flowcat_core::service::SttService;
 
 #[allow(clippy::duplicate_mod)] // each WS provider owns its own copy (feature-independent)
 #[path = "ws_stt_common.rs"]
 pub mod ws_stt;
 
-use ws_stt::{WsSttConfig, WsSttSession};
+use ws_stt::{base64_encode, pcm_le_bytes, WsSttConfig, WsSttSession};
 
-/// Gradium's realtime STT WSS host. The query string (encoding/sample_rate) is
-/// appended at connect time; the host is fixed — only the API key (header) and
-/// validated numeric params are caller-controlled (no SSRF surface).
-pub const GRADIUM_WSS_BASE: &str = "wss://api.gradium.ai/v1/stt/stream";
+/// Gradium's realtime STT WSS endpoint. The API key travels in the `x-api-key`
+/// header, never the URL — so the host is fixed (no SSRF surface).
+pub const GRADIUM_WSS: &str = "wss://api.gradium.ai/api/speech/asr";
+
+/// End-of-utterance gap: once a segment has arrived, this much further audio with
+/// **no** new `text` closes the user turn (one final transcript).
+pub const TURN_GAP_MS: u64 = 700;
 
 /// Gradium streaming-STT session.
 pub struct GradiumStt {
     api_key: String,
     sample_rate: u32,
-    base_url: String,
+    url: String,
     session: Option<WsSttSession>,
     muted: bool,
+    /// Accumulated text of the in-progress user turn (joined `text` segments).
+    turn_text: String,
+    /// Audio duration (ms) elapsed since the last new `text` segment — the
+    /// end-of-utterance clock, advanced by the incoming chunk cadence.
+    quiet_ms: u64,
 }
 
 impl GradiumStt {
-    /// Construct bound to `api_key` (default 16 kHz input).
+    /// Construct bound to `api_key` (default 16 kHz input — the cascaded carrier rate).
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
             api_key: api_key.into(),
             sample_rate: 16_000,
-            base_url: GRADIUM_WSS_BASE.to_string(),
+            url: GRADIUM_WSS.to_string(),
             muted: false,
             session: None,
+            turn_text: String::new(),
+            quiet_ms: 0,
         }
     }
 
-    /// Override the input sample rate (default 16 kHz).
+    /// Override the input sample rate (default 16 kHz). Sent to Gradium as the
+    /// `input_format` (`pcm_<rate>`), so it must match the PCM actually streamed.
     pub fn sample_rate(mut self, rate: u32) -> Self {
         self.sample_rate = rate;
         self
     }
 
-    /// Override the WSS base URL (for a non-default Gradium deployment).
+    /// Override the WSS URL (for a non-default Gradium deployment).
     pub fn base_url(mut self, url: impl Into<String>) -> Self {
-        self.base_url = url.into();
+        self.url = url.into();
         self
     }
 
-    /// The connect URL for this config (testable without a socket). The API key
-    /// is **never** placed in the URL (it travels in `Authorization`).
-    pub(crate) fn url(&self) -> String {
-        format!(
-            "{}?encoding=pcm_s16le&sample_rate={}",
-            self.base_url, self.sample_rate
-        )
+    /// The Gradium `setup` handshake (sent once, immediately after connect): the
+    /// model and the explicit input PCM rate (`pcm_16000` for the 16 kHz carrier).
+    fn setup_message(&self) -> String {
+        json!({
+            "type": "setup",
+            "model_name": "default",
+            "input_format": format!("pcm_{}", self.sample_rate),
+            "json_config": { "language": "en" },
+        })
+        .to_string()
     }
 }
 
@@ -91,15 +106,14 @@ impl SttService for GradiumStt {
 
     async fn start(&mut self, _params: &StartParams) -> Result<()> {
         let cfg = WsSttConfig {
-            url: self.url(),
-            headers: vec![(
-                "Authorization".to_string(),
-                format!("Bearer {}", self.api_key),
-            )],
-            init_message: None,
+            url: self.url.clone(),
+            headers: vec![("x-api-key".to_string(), self.api_key.clone())],
+            init_message: Some(self.setup_message()),
             decode: decode_message,
         };
-        self.session = Some(WsSttSession::connect(cfg).await?);
+        // Lazy: connect (and send `setup`) on the first audio chunk, so the socket
+        // connect never stalls the pipeline Start handshake.
+        self.session = Some(WsSttSession::lazy(cfg));
         Ok(())
     }
 
@@ -107,49 +121,84 @@ impl SttService for GradiumStt {
         if self.muted {
             return Ok(vec![]);
         }
+        let chunk_ms = if audio.sample_rate > 0 {
+            (audio.pcm.len() as u64 * 1000) / audio.sample_rate as u64
+        } else {
+            0
+        };
         let session = ws_stt::require(&mut self.session, "gradium")?;
-        session.send_pcm_binary(&audio).await?;
-        Ok(session.drain())
+        // Gradium takes audio base64-encoded inside a JSON envelope, not raw binary.
+        let envelope = json!({
+            "type": "audio",
+            "audio": base64_encode(&pcm_le_bytes(&audio)),
+        })
+        .to_string();
+        session.send_text(envelope).await?;
+
+        // Accrue any new `text` segments (carried as interims by `decode_message`)
+        // into the current turn; reset the quiet clock when something arrives.
+        let mut got_text = false;
+        for frame in session.drain() {
+            if let Frame::InterimTranscription { text, .. } = frame {
+                let seg = text.trim();
+                if !seg.is_empty() {
+                    if !self.turn_text.is_empty() {
+                        self.turn_text.push(' ');
+                    }
+                    self.turn_text.push_str(seg);
+                    got_text = true;
+                }
+            }
+        }
+        if got_text {
+            self.quiet_ms = 0;
+        } else {
+            self.quiet_ms = self.quiet_ms.saturating_add(chunk_ms);
+        }
+
+        // End of utterance: a segment exists and transcription has gone quiet long
+        // enough — emit exactly one final transcript (closes the user turn).
+        if !self.turn_text.is_empty() && self.quiet_ms >= TURN_GAP_MS {
+            let text = std::mem::take(&mut self.turn_text);
+            self.quiet_ms = 0;
+            return Ok(vec![Frame::Transcription {
+                text,
+                user_id: Arc::from("user"),
+                language: None,
+                final_: true,
+            }]);
+        }
+        Ok(vec![])
     }
 
     async fn set_muted(&mut self, muted: bool) {
+        // A new turn (mute = bot speaking / turn just closed): drop any half-turn
+        // remainder so the next user turn starts clean.
+        if muted {
+            self.turn_text.clear();
+            self.quiet_ms = 0;
+        }
         self.muted = muted;
     }
 }
 
-/// Decode one Gradium server message. **Pure.** `transcript` with non-empty
-/// `text` → final/interim by `is_final`; anything else → nothing.
+/// Decode one Gradium server message. **Pure.** A `text` segment with non-empty
+/// `text` → one [`Frame::InterimTranscription`] (the connector accumulates these and
+/// emits the turn-final itself); `end_text`/`ready`/VAD `step`/empty/malformed →
+/// nothing. Gradium has no per-message end-of-turn flag.
 pub(crate) fn decode_message(value: &Value) -> Vec<Frame> {
-    if value.get("type").and_then(|t| t.as_str()) != Some("transcript") {
+    if value.get("type").and_then(|t| t.as_str()) != Some("text") {
         return vec![];
     }
-    let transcript = value.get("text").and_then(|t| t.as_str()).unwrap_or("");
-    if transcript.is_empty() {
+    let text = value.get("text").and_then(|t| t.as_str()).unwrap_or("");
+    if text.trim().is_empty() {
         return vec![];
     }
-    let is_final = value
-        .get("is_final")
-        .and_then(|f| f.as_bool())
-        .unwrap_or(false);
-    let language = value
-        .get("language")
-        .and_then(|l| l.as_str())
-        .map(|l| Language(l.to_string()));
-    let user_id: Arc<str> = Arc::from("user");
-    if is_final {
-        vec![Frame::Transcription {
-            text: transcript.to_string(),
-            user_id,
-            language,
-            final_: true,
-        }]
-    } else {
-        vec![Frame::InterimTranscription {
-            text: transcript.to_string(),
-            user_id,
-            language,
-        }]
-    }
+    vec![Frame::InterimTranscription {
+        text: text.to_string(),
+        user_id: Arc::from("user"),
+        language: None,
+    }]
 }
 
 #[cfg(test)]
@@ -158,30 +207,37 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn url_encodes_params_and_omits_key() {
-        let c = GradiumStt::new("secret").sample_rate(8000);
-        let u = c.url();
-        assert!(u.starts_with("wss://api.gradium.ai/v1/stt/stream?encoding=pcm_s16le"));
-        assert!(u.contains("sample_rate=8000"));
-        assert!(!u.contains("secret"));
+    fn connects_to_the_asr_endpoint() {
+        assert_eq!(GRADIUM_WSS, "wss://api.gradium.ai/api/speech/asr");
+        let c = GradiumStt::new("secret");
+        assert_eq!(c.url, "wss://api.gradium.ai/api/speech/asr");
+        assert!(!c.url.contains("secret"));
     }
 
     #[test]
-    fn decode_final_and_interim() {
-        let f = json!({ "type": "transcript", "text": "book a dentist", "is_final": true, "language": "en" });
+    fn setup_carries_model_and_pcm_rate() {
+        let setup = GradiumStt::new("k").sample_rate(16_000).setup_message();
+        let v: Value = serde_json::from_str(&setup).unwrap();
+        assert_eq!(v["type"], "setup");
+        assert_eq!(v["model_name"], "default");
+        assert_eq!(v["input_format"], "pcm_16000");
+        assert_eq!(v["json_config"]["language"], "en");
+    }
+
+    #[test]
+    fn decode_text_segment_is_interim() {
+        // A `text` segment is carried as an interim; the connector accumulates these
+        // and emits the single turn-final once transcription goes quiet.
+        let f = json!({ "type": "text", "text": "book a dentist", "start_s": 0.5, "stream_id": 0 });
         assert!(matches!(&decode_message(&f)[..],
-            [Frame::Transcription { text, final_, .. }] if text == "book a dentist" && *final_));
-        let i = json!({ "type": "transcript", "text": "book a", "is_final": false });
-        assert!(matches!(
-            decode_message(&i).as_slice(),
-            [Frame::InterimTranscription { .. }]
-        ));
+            [Frame::InterimTranscription { text, .. }] if text == "book a dentist"));
     }
 
     #[test]
     fn decode_ignores_other_empty_and_malformed() {
+        assert!(decode_message(&json!({ "type": "end_text", "stop_s": 2.5 })).is_empty());
         assert!(decode_message(&json!({ "type": "ready" })).is_empty());
-        assert!(decode_message(&json!({ "type": "transcript", "text": "" })).is_empty());
+        assert!(decode_message(&json!({ "type": "text", "text": "  " })).is_empty());
         assert!(decode_message(&json!({ "text": "no type" })).is_empty());
         assert!(decode_message(&json!("nope")).is_empty());
     }
@@ -193,7 +249,7 @@ mod tests {
     async fn gradium_live_connects_and_streams() {
         let key = std::env::var("GRADIUM_API_KEY").expect("GRADIUM_API_KEY");
         let mut stt = GradiumStt::new(key);
-        stt.start(&StartParams::default()).await.expect("connect");
+        stt.start(&StartParams::default()).await.expect("start");
         let silence = Arc::new(AudioFrame::mono(vec![0i16; 1600], 16_000));
         let _ = stt.run_stt(silence).await.expect("run_stt");
     }

--- a/flowcat-services/src/stt/nvidia.rs
+++ b/flowcat-services/src/stt/nvidia.rs
@@ -28,12 +28,26 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::{Buf, BufMut};
+use futures::stream::{self, StreamExt};
+use http::uri::PathAndQuery;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tonic::client::Grpc;
+use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use tonic::metadata::MetadataValue;
+use tonic::transport::{ClientTlsConfig, Endpoint};
+use tonic::{Request, Status};
 
 use flowcat_core::error::{FlowcatError, Result};
 use flowcat_core::processor::frame::{AudioFrame, Frame, StartParams};
 use flowcat_core::service::SttService;
 
 use grpc_proto::Field;
+
+/// NVIDIA NIM's hosted Riva ASR gRPC host (NVCF). A self-hosted Riva server can be
+/// targeted with [`NvidiaStt::endpoint`].
+pub const NVIDIA_NVCF_HOST: &str = "grpc.nvcf.nvidia.com";
 
 /// Minimal hand-rolled protobuf (wire) + gRPC length-prefix framing for the Riva
 /// `StreamingRecognize` messages — **no `prost`** (tonic 0.14 core does not pull it;
@@ -198,11 +212,38 @@ pub const STREAMING_RECOGNIZE_PATH: &str =
 /// `AudioEncoding.LINEAR_PCM` (16-bit LE PCM) in `riva_audio.proto`.
 const AUDIO_ENCODING_LINEAR_PCM: i64 = 1;
 
+/// End-of-utterance gap: NVCF parakeet streams cumulative interims and (in practice)
+/// no `is_final`, so once an interim exists this much further audio with no new
+/// interim closes the user turn (one final transcript).
+const TURN_GAP_MS: u64 = 700;
+
+/// Live gRPC bidi connection state (present once [`SttService::start`] succeeds).
+struct Connection {
+    /// Sender into the outbound request stream; `run_stt` pushes encoded audio here.
+    /// Dropping it half-closes the request stream (clean teardown).
+    audio_tx: mpsc::UnboundedSender<Vec<u8>>,
+    /// Transcription frames the reader task has decoded so far (drained non-blocking).
+    frames: mpsc::UnboundedReceiver<Frame>,
+    /// The response-reader task; aborted on drop.
+    reader: JoinHandle<()>,
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.reader.abort();
+    }
+}
+
 /// NVIDIA Riva / Nemotron Speech streaming-STT service.
 pub struct NvidiaStt {
     /// API key for NIM-hosted Riva (`function-id`/bearer). Empty for a self-hosted
     /// Riva server that needs no auth.
     api_key: String,
+    /// gRPC host (default NVCF; a self-hosted Riva sets its own host).
+    host: String,
+    /// NVCF function id — the hosted ASR model to route to (NVCF only; empty for a
+    /// self-hosted Riva, which has no function routing).
+    function_id: String,
     /// BCP-47 language code (e.g. `en-US`).
     language_code: String,
     /// ASR model name (e.g. `parakeet-1.1b-en-US-asr-streaming`); empty ⇒ server
@@ -211,21 +252,47 @@ pub struct NvidiaStt {
     sample_rate: u32,
     interim_results: bool,
     muted: bool,
+    /// Live bidi connection — `None` until `start` opens it.
+    conn: Option<Connection>,
+    /// Latest cumulative interim text of the in-progress turn (Riva interims replace,
+    /// not append). Emitted as the turn-final once transcription goes quiet.
+    turn_text: String,
+    /// Audio ms since the last new interim — the end-of-utterance clock.
+    quiet_ms: u64,
 }
 
 impl NvidiaStt {
-    /// Construct bound to `api_key` (default `en-US`, server-default model, 16 kHz,
-    /// interim results on). Pass an empty key for an unauthenticated self-hosted
-    /// Riva.
+    /// Construct bound to `api_key` (default NVCF host, `en-US`, server-default model,
+    /// 16 kHz, interim results on). Pass an empty key for an unauthenticated
+    /// self-hosted Riva.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
             api_key: api_key.into(),
+            host: NVIDIA_NVCF_HOST.to_string(),
+            function_id: String::new(),
             language_code: "en-US".to_string(),
             model: String::new(),
             sample_rate: 16_000,
             interim_results: true,
             muted: false,
+            conn: None,
+            turn_text: String::new(),
+            quiet_ms: 0,
         }
+    }
+
+    /// Override the gRPC host (default `grpc.nvcf.nvidia.com`; set for a self-hosted
+    /// Riva server, e.g. `localhost:50051`).
+    pub fn endpoint(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+
+    /// Set the NVCF `function-id` (the hosted ASR model to route to). Required for
+    /// NIM-hosted Riva; leave empty for a self-hosted server.
+    pub fn function_id(mut self, id: impl Into<String>) -> Self {
+        self.function_id = id.into();
+        self
     }
 
     /// Override the language code (default `en-US`).
@@ -253,17 +320,71 @@ impl NvidiaStt {
     }
 
     /// gRPC request metadata. NIM-hosted Riva authenticates with an
-    /// `authorization: Bearer <key>` header; a self-hosted server with no key gets
-    /// no auth metadata. Returned as `(name, value)` pairs.
+    /// `authorization: Bearer <key>` header **and** a `function-id` routing the call
+    /// to the chosen ASR model; a self-hosted server with no key gets neither.
+    /// Returned as `(name, value)` pairs.
     pub fn auth_metadata(&self) -> Vec<(String, String)> {
-        if self.api_key.is_empty() {
-            vec![]
-        } else {
-            vec![(
+        let mut md = Vec::new();
+        if !self.api_key.is_empty() {
+            md.push((
                 "authorization".to_string(),
                 format!("Bearer {}", self.api_key),
-            )]
+            ));
         }
+        if !self.function_id.is_empty() {
+            md.push(("function-id".to_string(), self.function_id.clone()));
+        }
+        md
+    }
+}
+
+/// Raw-bytes [`tonic::codec::Codec`]: messages ARE the already-encoded
+/// `StreamingRecognizeRequest` bytes ([`encode_config_request`]/[`encode_audio_request`])
+/// and the raw `StreamingRecognizeResponse` bytes handed to [`decode_response`]. tonic
+/// owns the gRPC length-prefix framing, so the pure encode/decode fns are reused over
+/// the live stream verbatim. (Mirrors the Google STT codec — the two share the wire.)
+#[derive(Clone, Copy, Default)]
+pub(crate) struct RivaCodec;
+
+impl Codec for RivaCodec {
+    type Encode = Vec<u8>;
+    type Decode = Vec<u8>;
+    type Encoder = RawEncoder;
+    type Decoder = RawDecoder;
+    fn encoder(&mut self) -> RawEncoder {
+        RawEncoder
+    }
+    fn decoder(&mut self) -> RawDecoder {
+        RawDecoder
+    }
+}
+
+pub(crate) struct RawEncoder;
+impl Encoder for RawEncoder {
+    type Item = Vec<u8>;
+    type Error = Status;
+    fn encode(
+        &mut self,
+        item: Vec<u8>,
+        dst: &mut EncodeBuf<'_>,
+    ) -> std::result::Result<(), Status> {
+        dst.put_slice(&item);
+        Ok(())
+    }
+}
+
+pub(crate) struct RawDecoder;
+impl Decoder for RawDecoder {
+    type Item = Vec<u8>;
+    type Error = Status;
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> std::result::Result<Option<Vec<u8>>, Status> {
+        let n = src.remaining();
+        if n == 0 {
+            return Ok(None);
+        }
+        let mut v = vec![0u8; n];
+        src.copy_to_slice(&mut v);
+        Ok(Some(v))
     }
 }
 
@@ -346,35 +467,173 @@ impl SttService for NvidiaStt {
     }
 
     async fn start(&mut self, _params: &StartParams) -> Result<()> {
-        // Wire/auth seam complete; the live bidi transport needs tonic's `channel`
-        // + TLS (Cargo.toml-gated — see module docs). Build the config request +
-        // auth so the failure is explicit, not silent.
-        let _initial = encode_config_request(
+        // The gRPC dial + bidi stream run in a **background task**: NVCF cold-starts
+        // can take many seconds, and doing it inline (in `start` or `run_stt`) would
+        // stall the pipeline. `run_stt` just queues audio (buffered until the stream
+        // is up) and drains decoded frames.
+        let (audio_tx, audio_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (frame_tx, frame_rx) = mpsc::unbounded_channel::<Frame>();
+        let config_req = encode_config_request(
             &self.language_code,
             &self.model,
             self.sample_rate,
             self.interim_results,
         );
-        let _auth = self.auth_metadata();
-        Err(FlowcatError::Network(
-            "nvidia Riva STT: transport not fully wired — needs tonic `channel` + \
-             TLS feature (Cargo.toml-gated); wire/auth seam ready"
-                .into(),
-        ))
+        let host = self.host.clone();
+        let metadata = self.auth_metadata();
+        let reader = tokio::spawn(async move {
+            if let Err(e) = run_session(host, metadata, config_req, audio_rx, frame_tx).await {
+                tracing::error!(target: "flowcat_services::stt", error = %e, "nvidia STT session ended");
+            }
+        });
+        self.conn = Some(Connection {
+            audio_tx,
+            frames: frame_rx,
+            reader,
+        });
+        Ok(())
     }
 
-    async fn run_stt(&mut self, _audio: Arc<AudioFrame>) -> Result<Vec<Frame>> {
+    async fn run_stt(&mut self, audio: Arc<AudioFrame>) -> Result<Vec<Frame>> {
         if self.muted {
             return Ok(vec![]);
         }
-        Err(FlowcatError::Network(
-            "nvidia Riva STT: transport not fully wired (see start)".into(),
-        ))
+        let chunk_ms = if audio.sample_rate > 0 {
+            (audio.pcm.len() as u64 * 1000) / audio.sample_rate as u64
+        } else {
+            0
+        };
+        let conn = self
+            .conn
+            .as_mut()
+            .ok_or_else(|| FlowcatError::Network("nvidia STT: run_stt before start".into()))?;
+        // PCM i16 → little-endian bytes (the LINEAR_PCM wire format Riva expects).
+        let mut pcm_le = Vec::with_capacity(audio.pcm.len() * 2);
+        for s in &audio.pcm {
+            pcm_le.extend_from_slice(&s.to_le_bytes());
+        }
+        // Buffered: queues during NVCF cold-start, flushed once the stream is up.
+        let _ = conn.audio_tx.send(encode_audio_request(&pcm_le));
+
+        // Drain decoded results. Riva interims are cumulative (full hypothesis each
+        // time), so the latest replaces `turn_text`; a real `is_final` (rare on NVCF)
+        // closes the turn immediately.
+        let mut got_interim = false;
+        let mut finals = Vec::new();
+        while let Ok(f) = conn.frames.try_recv() {
+            match f {
+                Frame::InterimTranscription { text, .. } => {
+                    if !text.trim().is_empty() {
+                        self.turn_text = text;
+                        got_interim = true;
+                    }
+                }
+                Frame::Transcription { .. } => {
+                    self.turn_text.clear();
+                    self.quiet_ms = 0;
+                    finals.push(f);
+                }
+                other => finals.push(other),
+            }
+        }
+        if !finals.is_empty() {
+            return Ok(finals);
+        }
+        if got_interim {
+            self.quiet_ms = 0;
+        } else {
+            self.quiet_ms = self.quiet_ms.saturating_add(chunk_ms);
+        }
+        // End of utterance: an interim exists and transcription has gone quiet —
+        // emit the latest hypothesis as the single turn-final.
+        if !self.turn_text.is_empty() && self.quiet_ms >= TURN_GAP_MS {
+            let text = std::mem::take(&mut self.turn_text);
+            self.quiet_ms = 0;
+            return Ok(vec![Frame::Transcription {
+                text,
+                user_id: Arc::from("user"),
+                language: None,
+                final_: true,
+            }]);
+        }
+        Ok(vec![])
     }
 
     async fn set_muted(&mut self, muted: bool) {
+        // Bot speaking / turn closed: drop any half-turn remainder so the next user
+        // turn starts clean.
+        if muted {
+            self.turn_text.clear();
+            self.quiet_ms = 0;
+        }
         self.muted = muted;
     }
+}
+
+/// Background session: TLS-dial the gRPC host, open the bidi `StreamingRecognize`
+/// stream (config request first, then the buffered audio chunks), and forward every
+/// decoded `StreamingRecognizeResponse` as transcription [`Frame`]s to `frame_tx`.
+/// Runs for the life of the call; ends on stream close/error.
+async fn run_session(
+    host: String,
+    metadata: Vec<(String, String)>,
+    config_req: Vec<u8>,
+    audio_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    frame_tx: mpsc::UnboundedSender<Frame>,
+) -> Result<()> {
+    let tls = ClientTlsConfig::new()
+        .domain_name(host.clone())
+        .with_webpki_roots();
+    let endpoint = Endpoint::from_shared(format!("https://{host}"))
+        .map_err(|e| FlowcatError::Network(format!("nvidia endpoint: {e}")))?
+        .tls_config(tls)
+        .map_err(|e| FlowcatError::Network(format!("nvidia tls: {e}")))?;
+    let channel = endpoint
+        .connect()
+        .await
+        .map_err(|e| FlowcatError::Network(format!("nvidia connect: {e}")))?;
+
+    let audio_stream = stream::unfold(audio_rx, |mut rx| async move {
+        rx.recv().await.map(|m| (m, rx))
+    });
+    let out_stream = stream::once(async move { config_req }).chain(audio_stream);
+
+    let mut request = Request::new(out_stream);
+    for (name, value) in metadata {
+        let key: tonic::metadata::MetadataKey<_> = name
+            .parse()
+            .map_err(|e| FlowcatError::Network(format!("nvidia metadata key: {e}")))?;
+        let val: MetadataValue<_> = value
+            .parse()
+            .map_err(|e| FlowcatError::Network(format!("nvidia metadata value: {e}")))?;
+        request.metadata_mut().insert(key, val);
+    }
+
+    let path = PathAndQuery::from_static(STREAMING_RECOGNIZE_PATH);
+    let mut grpc = Grpc::new(channel);
+    grpc.ready()
+        .await
+        .map_err(|e| FlowcatError::Network(format!("nvidia grpc not ready: {e}")))?;
+    let response = grpc
+        .streaming(request, path, RivaCodec)
+        .await
+        .map_err(|e| FlowcatError::Network(format!("nvidia streaming: {e}")))?;
+
+    let mut inbound = response.into_inner();
+    loop {
+        match inbound.message().await {
+            Ok(Some(bytes)) => {
+                for frame in decode_response(&bytes) {
+                    if frame_tx.send(frame).is_err() {
+                        return Ok(()); // consumer gone
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(status) => return Err(FlowcatError::Network(format!("nvidia stream: {status}"))),
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -466,21 +725,29 @@ mod tests {
         assert!(unkeyed.auth_metadata().is_empty());
     }
 
-    #[tokio::test]
-    async fn start_reports_transport_seam_clearly() {
-        let mut stt = NvidiaStt::new("k");
-        let err = stt.start(&StartParams::default()).await.unwrap_err();
-        assert!(err.to_string().contains("not fully wired"));
+    #[test]
+    fn auth_metadata_carries_bearer_and_function_id() {
+        let stt = NvidiaStt::new("k").function_id("fn-123");
+        let md = stt.auth_metadata();
+        assert!(md
+            .iter()
+            .any(|(n, v)| n == "authorization" && v == "Bearer k"));
+        assert!(md.iter().any(|(n, v)| n == "function-id" && v == "fn-123"));
+        // Self-hosted (no key, no function) → no metadata.
+        assert!(NvidiaStt::new("").auth_metadata().is_empty());
     }
 
-    /// Live smoke (requires `NVIDIA_API_KEY` + the tonic transport feature). Ignored
-    /// until the transport is wired. Run with:
-    /// `NVIDIA_API_KEY=… cargo test -p flowcat-services --features stt-nvidia -- --ignored nvidia_live`
+    /// Live smoke (requires `NVIDIA_API_KEY` + a NIM ASR `NVIDIA_FUNCTION_ID`). Run:
+    /// `NVIDIA_API_KEY=… NVIDIA_FUNCTION_ID=… cargo test -p flowcat-services \
+    ///   --features stt-nvidia -- --ignored nvidia_live`
     #[tokio::test]
-    #[ignore = "transport not wired (needs tonic channel+TLS) + NVIDIA_API_KEY"]
+    #[ignore = "requires NVIDIA_API_KEY + NVIDIA_FUNCTION_ID (NVCF ASR)"]
     async fn nvidia_live_connects_and_streams() {
         let key = std::env::var("NVIDIA_API_KEY").expect("NVIDIA_API_KEY");
-        let mut stt = NvidiaStt::new(key);
-        let _ = stt.start(&StartParams::default()).await;
+        let function_id = std::env::var("NVIDIA_FUNCTION_ID").expect("NVIDIA_FUNCTION_ID");
+        let mut stt = NvidiaStt::new(key).function_id(function_id);
+        stt.start(&StartParams::default()).await.expect("start");
+        let silence = Arc::new(AudioFrame::mono(vec![0i16; 1600], 16_000));
+        let _ = stt.run_stt(silence).await.expect("run_stt");
     }
 }

--- a/flowcat-services/src/stt/whisper_local.rs
+++ b/flowcat-services/src/stt/whisper_local.rs
@@ -219,19 +219,44 @@ fn run_inference(ctx: &WhisperContext, language: Option<&str>, samples: &[f32]) 
     Ok(out.trim().to_string())
 }
 
-/// Turn whisper's finalized segment text into transcription frames (empty text →
-/// nothing). **Pure** — the decode seam the fixture tests drive.
+/// Turn whisper's finalized segment text into transcription frames. **Pure** — the
+/// decode seam the fixture tests drive. whisper.cpp annotates non-speech audio with
+/// bracketed/parenthesised markers (`[BLANK_AUDIO]`, `[Music]`, `(silence)`, etc.);
+/// a segment that is only such markers (or empty/punctuation) yields **nothing** so
+/// silence never reaches the LLM as a "user turn".
 pub fn decode_segment_text(text: &str) -> Vec<Frame> {
-    let text = text.trim();
-    if text.is_empty() {
+    let spoken = strip_non_speech(text);
+    // Require at least one real word character — drops empty / whitespace /
+    // punctuation-only / pure-annotation segments.
+    if !spoken.chars().any(|c| c.is_alphanumeric()) {
         return vec![];
     }
     vec![Frame::Transcription {
-        text: text.to_string(),
+        text: spoken,
         user_id: Arc::from("user"),
         language: None,
         final_: true,
     }]
+}
+
+/// Strip whisper.cpp's non-speech annotations — `[...]` and `(...)` spans like
+/// `[BLANK_AUDIO]` / `[Music]` / `(silence)` — and collapse surrounding whitespace,
+/// leaving only the spoken words. **Pure.**
+fn strip_non_speech(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut square = 0i32;
+    let mut round = 0i32;
+    for c in text.chars() {
+        match c {
+            '[' => square += 1,
+            ']' => square = (square - 1).max(0),
+            '(' => round += 1,
+            ')' => round = (round - 1).max(0),
+            _ if square > 0 || round > 0 => {}
+            _ => out.push(c),
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Thread count for whisper inference, with a safe fallback.
@@ -338,6 +363,19 @@ mod tests {
     fn decode_empty_segment_yields_nothing() {
         assert!(decode_segment_text("").is_empty());
         assert!(decode_segment_text("   \n ").is_empty());
+    }
+
+    #[test]
+    fn decode_drops_non_speech_annotations() {
+        // whisper.cpp tags silence/noise; these must never become a user turn.
+        assert!(decode_segment_text("[BLANK_AUDIO]").is_empty());
+        assert!(decode_segment_text("[Music]").is_empty());
+        assert!(decode_segment_text("(silence)").is_empty());
+        assert!(decode_segment_text(" [Music] . ").is_empty());
+        // Real speech with a stray annotation keeps just the words.
+        let frames = decode_segment_text("[Music] book a dentist");
+        assert!(matches!(&frames[..],
+            [Frame::Transcription { text, .. }] if text == "book a dentist"));
     }
 
     #[test]

--- a/flowcat-services/src/tts/camb.rs
+++ b/flowcat-services/src/tts/camb.rs
@@ -6,10 +6,12 @@
 //! (cross-checked against pipecat `services/camb/tts.py`, which drives the same
 //! endpoint via the Camb SDK): an `x-api-key: <key>` header and a JSON body
 //! `{ text, voice_id, language, speech_model, output_configuration: { format:
-//! "pcm_s16le" } }`. The response is **raw little-endian PCM** (`pcm_s16le`)
-//! streamed back; the trait buffers the whole utterance so the decode is a
-//! straight [`http::pcm_from_le_bytes`]. The request encode ([`build_body`]) is a
-//! pure, unit-tested seam. Behind the `tts-camb` feature.
+//! "wav" } }`. We request `wav` (not `pcm_s16le`): Camb's raw `pcm_s16le` stream
+//! comes back **truncated** (~40 % of the utterance), while `wav` returns the full
+//! audio as a canonical 48 kHz RIFF/WAVE body. The header is stripped with
+//! [`http::strip_wav_header`] and the PCM decoded by [`http::pcm_from_le_bytes`].
+//! The request encode ([`build_body`]) is a pure, unit-tested seam. Behind the
+//! `tts-camb` feature.
 
 use std::sync::Arc;
 
@@ -24,7 +26,9 @@ use flowcat_core::service::TtsService;
 #[path = "http_tts_common.rs"]
 pub mod http;
 
-use http::{pcm_from_le_bytes, tts_frames, HttpTtsBody, HttpTtsClient, HttpTtsRequest};
+use http::{
+    pcm_from_le_bytes, strip_wav_header, tts_frames, HttpTtsBody, HttpTtsClient, HttpTtsRequest,
+};
 
 /// Camb.ai's default API base. The key rides the `x-api-key` header.
 pub const CAMB_API_BASE: &str = "https://client.camb.ai";
@@ -43,9 +47,13 @@ pub struct CambTts {
 
 impl CambTts {
     /// Construct bound to `api_key` + `voice_id` (default model `mars-instruct`,
-    /// language `en-us`, 22050 Hz `pcm_s16le`). Camb requires a region-coded language
+    /// language `en-us`, 48000 Hz `pcm_s16le`). Camb requires a region-coded language
     /// (`en-us`/`en-au`/… — bare `en` is rejected with a 422); override via
     /// [`language`](Self::language).
+    ///
+    /// Camb **ignores** the requested `sample_rate` and always streams its native
+    /// 48 kHz, so we tag the PCM at 48 kHz (declaring anything else plays the audio
+    /// at the wrong speed/pitch).
     pub fn new(api_key: impl Into<String>, voice_id: impl Into<String>) -> Self {
         Self {
             client: HttpTtsClient::new("camb"),
@@ -54,7 +62,7 @@ impl CambTts {
             voice_id: voice_id.into(),
             language: "en-us".to_string(),
             model: "mars-instruct".to_string(),
-            sample_rate: 24_000,
+            sample_rate: 48_000,
             ctx_counter: 0,
         }
     }
@@ -71,7 +79,9 @@ impl CambTts {
         self
     }
 
-    /// Override the output sample rate (default 22050 Hz).
+    /// Override the output sample rate (default 48000 Hz). Note Camb ignores this
+    /// over the wire and always returns 48 kHz, so changing it only mis-tags the
+    /// PCM — kept for API uniformity.
     pub fn with_sample_rate(mut self, rate: u32) -> Self {
         self.sample_rate = rate;
         self
@@ -115,7 +125,7 @@ impl TtsService for CambTts {
         };
         let raw = self.client.post(req).await?;
         Ok(tts_frames(
-            pcm_from_le_bytes(&raw),
+            pcm_from_le_bytes(strip_wav_header(&raw)),
             self.sample_rate,
             context_id,
         ))
@@ -123,8 +133,8 @@ impl TtsService for CambTts {
 }
 
 /// Build the Camb `/apis/tts-stream` request body (pure seam). The output
-/// `sample_rate` is requested explicitly so Camb's stream matches the rate we tag
-/// the PCM with (otherwise Camb picks its own and the audio plays at the wrong rate).
+/// `sample_rate` is still sent for completeness, but Camb ignores it and always
+/// streams its native 48 kHz `pcm_s16le` — the caller must tag the PCM at 48 kHz.
 pub fn build_body(
     text: &str,
     voice_id: &str,
@@ -143,7 +153,7 @@ pub fn build_body(
         "voice_id": voice,
         "language": language,
         "speech_model": model,
-        "output_configuration": { "format": "pcm_s16le", "sample_rate": sample_rate },
+        "output_configuration": { "format": "wav", "sample_rate": sample_rate },
     })
 }
 
@@ -159,7 +169,7 @@ mod tests {
         assert_eq!(body["language"], "en");
         assert_eq!(body["output_configuration"]["sample_rate"], 24_000);
         assert_eq!(body["speech_model"], "mars-instruct");
-        assert_eq!(body["output_configuration"]["format"], "pcm_s16le");
+        assert_eq!(body["output_configuration"]["format"], "wav");
     }
 
     #[test]
@@ -177,7 +187,8 @@ mod tests {
     fn client_defaults() {
         let tts = CambTts::new("k", "v-42");
         assert_eq!(tts.name(), "camb");
-        assert_eq!(tts.sample_rate(), 24_000);
+        assert_eq!(tts.sample_rate(), 48_000); // Camb's fixed native rate
+
         assert_eq!(tts.url(), "https://client.camb.ai/apis/tts-stream");
     }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
## What & why

This branch repairs four provider connectors that were emitting garbled/truncated
audio or junk transcripts. Each fix is an isolated change to a single connector,
with no impact on the dependency-free default build.

**TTS**
- **camb** — truncated/garbled. `pcm_s16le` came back ~40% truncated, and the
  connector declared 24 kHz while camb always streams 48 kHz. Now requests `wav`
  (full audio), strips the header, and tags it 48 kHz.

**STT**
- **gradium** — wrong endpoint (404). Pointed at the real one
  (`wss://api.gradium.ai/api/speech/asr`, `x-api-key`, setup + base64 audio + text
  segments). Word-level segments with no end-of-turn were split into many turns;
  now accumulates and emits one final after a short quiet gap.
- **whisper_local** — replied to junk turns. whisper.cpp returns markers like
  `[BLANK_AUDIO]`, `[Music]`, `(silence)` on quiet audio that were passed through as
  transcripts. Now strips `[..]`/`(..)` annotations and drops a segment with no real
  words left.
- **nvidia (Riva)** — connector never worked (`start`/`run_stt` returned "transport
  not fully wired"). Built the live bidi `StreamingRecognize` stream against NIM/NVCF
  (`grpc.nvcf.nvidia.com`, TLS, bearer auth + function-id) with a raw-bytes tonic
  codec, mirroring the google STT transport. Connect happens in a background task (an
  eager connect in `start()` stalled pipeline start and the greeting never fired),
  audio is buffered during NVCF cold-start, and cumulative interims with no
  `is_final` are accumulated into one final after a short quiet gap.
  `stt-nvidia` now enables the tonic channel + tls features.

Closes #28, closes #27, closes #26, closes #25

## Type of change

- [x] Bug fix
- [ ] New provider / transport / serializer
- [ ] New feature or processor
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] `cargo build` (default features) compiles and pulls **no** new networked
      dependency into the default build.
- [x] `cargo test` is green and **offline** (no test hits the network).
- [x] `cargo clippy --all-targets` is clean.
- [x] `cargo fmt --all` has been run.
- [x] Every new source file starts with the SPDX header
      `// SPDX-License-Identifier: Apache-2.0`.
- [ ] If a provider was added: it is `dep:`-gated behind its own Cargo feature,
      registered in the category `mod.rs` + the `*-all` umbrella, and covered by a
      fixture / known-answer test. `FEATURES.md` is updated.
      (N/A — no new providers; the nvidia change is `dep:`-gated under the existing
      `stt-nvidia` feature, now enabling tonic channel+tls.)
- [ ] If a new dependency or third-party protocol was introduced: `NOTICE` is
      updated as needed.
- [x] The PR honestly states what is **fixture-tested** vs **live-verified**.

## Notes for reviewers

- These were verified against live provider sockets during debugging; the committed
  tests remain offline encode/decode fixtures per the repo's testing rules.
- The nvidia STT change enables `tonic` channel + tls under the `stt-nvidia`
  feature; confirm this stays gated and does not leak into the default build.