### PR TITLE
feat(server): split out server-helper/webrtc-helper features, no forced flowcat-services/*-all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,12 @@ jobs:
         run: |
           cargo clippy -p flowcat-server --locked --features webrtc --all-targets -- -D warnings
           cargo test -p flowcat-server --locked --features webrtc
+      # Guard the embedder seam (#30): the framework + WebRTC helper surface
+      # (`webrtc::handle_offer`, `build_router`) MUST compile with NO
+      # `flowcat-services/*-all` bundle, so an embedder can pair it with its own
+      # curated connector set. If this breaks, the framework grew a hard connector
+      # dependency it shouldn't have.
+      - name: flowcat-server (webrtc-helper — no connector bundles)
+        run: |
+          cargo clippy -p flowcat-server --locked --features webrtc-helper --all-targets -- -D warnings
+          cargo test -p flowcat-server --locked --features webrtc-helper

--- a/flowcat-server/Cargo.toml
+++ b/flowcat-server/Cargo.toml
@@ -11,25 +11,47 @@ categories.workspace = true
 
 [features]
 default = []
-# The HTTP server binary (axum) + the providers it can run. Pulls the runtime
-# deps and enables the full flowcat-services connector set so the binary can run
-# any provider named in the config. The default (no-feature) build is just the
-# library: the config schema + StaticSession + the run-orchestration helpers.
-server = [
+# --- Framework surface (no bundled connectors) ----------------------------------
+# `server-helper` is the axum HTTP/transport framework — `build_router`, `AppState`,
+# the Plivo media WS, the `run_call*` orchestration — generic over the embedder's
+# `SessionSource` + `AgentBrain`, WITHOUT forcing any `flowcat-services/*-all`
+# bundle. An embedder enables this plus its OWN curated `flowcat-services/*`
+# connector features (which unify into the shared factory). It pulls only the
+# runtime deps the framework itself needs.
+server-helper = [
     "dep:axum",
     "dep:tokio",
     "dep:futures-util",
     "dep:tracing-subscriber",
     "dep:flowcat-agent",
     "dep:flowcat-telephony",
+]
+# `server-helper` + the browser WebRTC playground surface: the page, the SDP-offer
+# endpoint (`webrtc::offer` / the reusable `webrtc::handle_offer` signaling helper)
+# over a str0m transport, and the live-events WS — still WITHOUT any connector
+# bundle. This is what an embedder enables to reuse `handle_offer` with its own
+# `flowcat-services/*` selection (issue #30).
+webrtc-helper = [
+    "server-helper",
+    "dep:flowcat-transports",
+    "flowcat-transports/webrtc-str0m",
+]
+
+# --- Standalone binary (framework + every connector bundle) ----------------------
+# The HTTP server binary (axum): `server-helper` plus the full flowcat-services
+# connector set, so the binary can run any provider named in a config. The default
+# (no-feature) build is just the library: the config schema + StaticSession + the
+# run-orchestration helpers.
+server = [
+    "server-helper",
     "flowcat-services/stt-all",
     "flowcat-services/tts-all",
     "flowcat-services/llm-all",
     "flowcat-services/realtime-all",
 ]
-# The browser WebRTC playground: the page, the SDP-offer endpoint over a str0m
-# transport, and the live-events WebSocket. Implies `server`.
-webrtc = ["server", "dep:flowcat-transports", "flowcat-transports/webrtc-str0m"]
+# The full browser WebRTC playground binary: the `webrtc-helper` surface plus the
+# complete `server` connector set. (`webrtc-helper` + `server`.)
+webrtc = ["webrtc-helper", "server"]
 
 [dependencies]
 flowcat-core = { path = "../flowcat-core", version = "0.1.0" }

--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -11,14 +11,20 @@
 //! - [`run`] — assemble + run the flowcat pipeline for one call from the config
 //!   topology (realtime or cascaded), resolving provider keys from the env.
 //!
-//! With the `server` Cargo feature, the crate also builds the **binary**: an axum
-//! HTTP server (health, the Plivo media WebSocket, the Plivo answer XML) that runs
-//! the configured agent. The default (no-feature) build is library-only and pulls
-//! no axum/tokio.
+//! The axum HTTP/transport framework — `build_router`, `AppState`, the media WS, and
+//! (with WebRTC) the reusable [`webrtc::handle_offer`] signaling helper — is gated
+//! behind the **`server-helper`** feature; the browser playground surface adds
+//! **`webrtc-helper`**. Neither helper pulls a `flowcat-services/*-all` bundle, so an
+//! embedder reuses this surface with its OWN curated connector set (the factory
+//! unifies in whatever `flowcat-services/*` features the embedder enables). The
+//! standalone **binary** is built by the **`server`** feature (`server-helper` + every
+//! connector bundle) — or **`webrtc`** (`webrtc-helper` + `server`) for the full
+//! browser playground binary. The default (no-feature) build is library-only and
+//! pulls no axum/tokio.
 //!
 //! ## A reusable framework, not just a binary
 //!
-//! With the `server` feature, the HTTP/transport surface (`build_router` over
+//! With the `server-helper` feature, the HTTP/transport surface (`build_router` over
 //! `AppState`) is **generic over the embedder's `SessionSource` and `AgentBrain`**.
 //! The zero-config default (a [`StaticSession`] resolving one configured agent plus
 //! a `DeclarativeBrain` factory) is built by `AppState::new` and powers the
@@ -31,22 +37,22 @@ pub mod config;
 pub mod run;
 pub mod session;
 
-#[cfg(feature = "server")]
+#[cfg(feature = "server-helper")]
 pub mod server;
-#[cfg(feature = "server")]
+#[cfg(feature = "server-helper")]
 pub mod socket;
 
-#[cfg(feature = "webrtc")]
+#[cfg(feature = "webrtc-helper")]
 pub mod events;
-#[cfg(feature = "webrtc")]
+#[cfg(feature = "webrtc-helper")]
 pub mod webrtc;
 
 pub use config::{ConfigError, ServerConfig, TopologyConfig};
 pub use run::{env_spec_resolver, run_call, run_call_with, SpecResolver};
 pub use session::StaticSession;
 
-#[cfg(feature = "server")]
+#[cfg(feature = "server-helper")]
 pub use server::{build_router, AppState, BrainFactory};
 
-#[cfg(feature = "webrtc")]
+#[cfg(feature = "webrtc-helper")]
 pub use webrtc::{handle_offer, OfferParams};

--- a/flowcat-server/src/server.rs
+++ b/flowcat-server/src/server.rs
@@ -53,14 +53,14 @@ pub struct AppState<S, B> {
     pub(crate) spec_resolver: SpecResolver,
     pub(crate) public_url: Arc<Option<String>>,
     /// Per-call live-event channels for the WebRTC playground.
-    #[cfg(feature = "webrtc")]
+    #[cfg(feature = "webrtc-helper")]
     pub(crate) events: Arc<crate::events::EventRegistry>,
     /// Monotonic per-call id source (`pc-<n>`).
-    #[cfg(feature = "webrtc")]
+    #[cfg(feature = "webrtc-helper")]
     pub(crate) next_pc: Arc<std::sync::atomic::AtomicU64>,
     /// Concrete IPv4 the str0m media socket binds (str0m rejects 0.0.0.0); from
     /// `FLOWCAT_WEBRTC_BIND_IP`, default loopback.
-    #[cfg(feature = "webrtc")]
+    #[cfg(feature = "webrtc-helper")]
     pub(crate) webrtc_bind_ip: std::net::Ipv4Addr,
 }
 
@@ -74,11 +74,11 @@ impl<S, B> Clone for AppState<S, B> {
             topology: Arc::clone(&self.topology),
             spec_resolver: Arc::clone(&self.spec_resolver),
             public_url: Arc::clone(&self.public_url),
-            #[cfg(feature = "webrtc")]
+            #[cfg(feature = "webrtc-helper")]
             events: Arc::clone(&self.events),
-            #[cfg(feature = "webrtc")]
+            #[cfg(feature = "webrtc-helper")]
             next_pc: Arc::clone(&self.next_pc),
-            #[cfg(feature = "webrtc")]
+            #[cfg(feature = "webrtc-helper")]
             webrtc_bind_ip: self.webrtc_bind_ip,
         }
     }
@@ -103,11 +103,11 @@ impl<S, B> AppState<S, B> {
             // convention). An embedder swaps in its own via `with_spec_resolver`.
             spec_resolver: Arc::new(run::env_spec_resolver),
             public_url: Arc::new(public_url),
-            #[cfg(feature = "webrtc")]
+            #[cfg(feature = "webrtc-helper")]
             events: Arc::new(crate::events::EventRegistry::new()),
-            #[cfg(feature = "webrtc")]
+            #[cfg(feature = "webrtc-helper")]
             next_pc: Arc::new(std::sync::atomic::AtomicU64::new(1)),
-            #[cfg(feature = "webrtc")]
+            #[cfg(feature = "webrtc-helper")]
             webrtc_bind_ip: webrtc_bind_ip_from_env(),
         }
     }
@@ -144,7 +144,7 @@ impl AppState<StaticSession, DeclarativeBrain> {
 
 /// Resolve the WebRTC media bind IP from `FLOWCAT_WEBRTC_BIND_IP` (default
 /// `127.0.0.1`; str0m advertises it as the host ICE candidate and rejects 0.0.0.0).
-#[cfg(feature = "webrtc")]
+#[cfg(feature = "webrtc-helper")]
 fn webrtc_bind_ip_from_env() -> std::net::Ipv4Addr {
     std::env::var("FLOWCAT_WEBRTC_BIND_IP")
         .ok()
@@ -171,7 +171,7 @@ where
             get(answer_plivo::<S, B>),
         );
     // The browser playground (page + WebRTC offer + live-events WS).
-    #[cfg(feature = "webrtc")]
+    #[cfg(feature = "webrtc-helper")]
     let router = router
         .route("/", get(crate::webrtc::playground_page))
         .route(


### PR DESCRIPTION
## Summary

Splits the `flowcat-server` feature graph so an embedder can reuse the axum
HTTP/transport framework and the WebRTC `handle_offer` signaling helper **without**
being forced to pull every `flowcat-services/*-all` connector bundle (issue #30).

- **`server-helper`** — the axum framework (`build_router`, `AppState`, the Plivo
  media WS, `run_call*`), generic over the embedder's `SessionSource` + `AgentBrain`,
  with **no** connector bundle. An embedder pairs it with its own curated
  `flowcat-services/*` features (they unify into the shared factory).
- **`webrtc-helper`** — `server-helper` + the browser playground surface (page,
  `webrtc::offer` / reusable `webrtc::handle_offer`, live-events WS) over str0m, still
  **no** connector bundle.
- **`server`** — now `server-helper` + the four `*-all` bundles (the standalone
  binary that can run any provider named in a config).
- **`webrtc`** — now `webrtc-helper` + `server` (the full playground binary).

All `cfg(feature = "server")` / `"webrtc")` gates are rewritten to the `-helper`
variants. The standalone binary still gates on `server`, and `webrtc` implies
`server`, so the binary build is unchanged.

## CI

Adds a guard job that builds `--features webrtc-helper` (clippy + tests) to prove the
framework + WebRTC helper surface compiles with **no** `flowcat-services/*-all`
bundle — i.e. the framework hasn't grown a hard connector dependency.

## Verification

- `webrtc-helper` clippy + tests: clean (29 passed).
- Full `webrtc` clippy: clean.
- `--features server` (no webrtc, incl. binary): compiles.
- Default build pulls no `axum`/`str0m`; `webrtc-helper` leaks no provider connector.
- `cargo fmt --all --check`: clean.
