### PR TITLE
fix(webrtc): bind the media socket locally, advertise the public IP (NAT/GKE)

### DIFF
--- a/flowcat-server/src/server.rs
+++ b/flowcat-server/src/server.rs
@@ -58,10 +58,14 @@ pub struct AppState<S, B> {
     /// Monotonic per-call id source (`pc-<n>`).
     #[cfg(feature = "webrtc-helper")]
     pub(crate) next_pc: Arc<std::sync::atomic::AtomicU64>,
-    /// Concrete IPv4 the str0m media socket binds (str0m rejects 0.0.0.0); from
-    /// `FLOWCAT_WEBRTC_BIND_IP`, default loopback.
+    /// IPv4 the str0m media socket binds; from `FLOWCAT_WEBRTC_BIND_IP`, default
+    /// loopback. May be `0.0.0.0` when `webrtc_advertise_ip` supplies the candidate.
     #[cfg(feature = "webrtc-helper")]
     pub(crate) webrtc_bind_ip: std::net::Ipv4Addr,
+    /// IPv4 advertised as the host ICE candidate (decoupled from the bind addr);
+    /// from `FLOWCAT_WEBRTC_ADVERTISE_IP`, `None` → advertise the bound addr.
+    #[cfg(feature = "webrtc-helper")]
+    pub(crate) webrtc_advertise_ip: Option<std::net::Ipv4Addr>,
 }
 
 // Hand-written so the bound is on the `Arc`s we actually hold, not on `S`/`B`
@@ -80,6 +84,8 @@ impl<S, B> Clone for AppState<S, B> {
             next_pc: Arc::clone(&self.next_pc),
             #[cfg(feature = "webrtc-helper")]
             webrtc_bind_ip: self.webrtc_bind_ip,
+            #[cfg(feature = "webrtc-helper")]
+            webrtc_advertise_ip: self.webrtc_advertise_ip,
         }
     }
 }
@@ -109,6 +115,8 @@ impl<S, B> AppState<S, B> {
             next_pc: Arc::new(std::sync::atomic::AtomicU64::new(1)),
             #[cfg(feature = "webrtc-helper")]
             webrtc_bind_ip: webrtc_bind_ip_from_env(),
+            #[cfg(feature = "webrtc-helper")]
+            webrtc_advertise_ip: webrtc_advertise_ip_from_env(),
         }
     }
 
@@ -143,13 +151,23 @@ impl AppState<StaticSession, DeclarativeBrain> {
 }
 
 /// Resolve the WebRTC media bind IP from `FLOWCAT_WEBRTC_BIND_IP` (default
-/// `127.0.0.1`; str0m advertises it as the host ICE candidate and rejects 0.0.0.0).
+/// `127.0.0.1`). May be `0.0.0.0` when `FLOWCAT_WEBRTC_ADVERTISE_IP` is set.
 #[cfg(feature = "webrtc-helper")]
 fn webrtc_bind_ip_from_env() -> std::net::Ipv4Addr {
     std::env::var("FLOWCAT_WEBRTC_BIND_IP")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(std::net::Ipv4Addr::LOCALHOST)
+}
+
+/// Resolve the advertised host-ICE-candidate IP from `FLOWCAT_WEBRTC_ADVERTISE_IP`
+/// (decoupled from the bind IP); `None` → advertise the bound addr.
+#[cfg(feature = "webrtc-helper")]
+fn webrtc_advertise_ip_from_env() -> Option<std::net::Ipv4Addr> {
+    std::env::var("FLOWCAT_WEBRTC_ADVERTISE_IP")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse().ok())
 }
 
 /// Assemble the axum router over the shared [`AppState`].

--- a/flowcat-server/src/webrtc.rs
+++ b/flowcat-server/src/webrtc.rs
@@ -64,9 +64,14 @@ pub async fn playground_page() -> Html<&'static str> {
 pub struct OfferParams<B, S, G> {
     /// The browser's SDP offer (post-ICE-gathering, so it carries candidates).
     pub sdp: String,
-    /// Concrete IPv4 the media socket binds (str0m advertises it as the host ICE
-    /// candidate and rejects 0.0.0.0); the caller chooses the interface — security.
+    /// IPv4 the media socket binds; the caller chooses the interface — security.
+    /// May be `0.0.0.0` (bind all) when `advertise_ip` supplies the candidate IP.
     pub bind_ip: Ipv4Addr,
+    /// IP advertised as the host ICE candidate (str0m rejects 0.0.0.0). `Some`
+    /// decouples it from `bind_ip` — bind the wildcard, advertise a 1:1-NAT public
+    /// IP (the SIP path's bind-UNSPECIFIED / advertise-public_ip pattern). `None`
+    /// advertises the bound addr (the local default).
+    pub advertise_ip: Option<Ipv4Addr>,
     /// Pipeline-facing carrier sample rate the str0m transport resamples to.
     pub carrier_rate: u32,
     /// Which providers to run + how their specs (keys) resolve.
@@ -110,6 +115,7 @@ where
     let OfferParams {
         sdp,
         bind_ip,
+        advertise_ip,
         carrier_rate,
         topology,
         resolver,
@@ -121,14 +127,16 @@ where
         keepalive,
     } = params;
 
-    // Bind the media socket on the chosen interface (str0m advertises it as the
-    // host ICE candidate and rejects 0.0.0.0). An io error here is the caller's 5xx.
+    // Bind the media socket on the chosen interface (may be 0.0.0.0). An io error
+    // here is the caller's 5xx.
     let bind = SocketAddr::new(IpAddr::V4(bind_ip), 0);
     let socket = tokio::net::UdpSocket::bind(bind).await?;
 
-    // Accept the offer → the str0m transport + the SDP answer. A bad offer is an Err
-    // with no peer created.
-    let (transport, answer) = WebRtcTransport::accept_offer(&sdp, socket, carrier_rate)?;
+    // Accept the offer → the str0m transport + the SDP answer. The advertised host
+    // candidate is `advertise_ip` (when set), decoupled from the bound addr. A bad
+    // offer is an Err with no peer created.
+    let (transport, answer) =
+        WebRtcTransport::accept_offer(&sdp, socket, advertise_ip.map(IpAddr::V4), carrier_rate)?;
 
     // Run the call detached; the answer goes back to the browser now.
     info!(run_id, "webrtc offer accepted; running call detached");
@@ -200,6 +208,7 @@ where
     let answer = handle_offer(OfferParams {
         sdp: body.sdp,
         bind_ip: state.webrtc_bind_ip,
+        advertise_ip: state.webrtc_advertise_ip,
         carrier_rate: WEBRTC_CARRIER_RATE,
         topology: (*state.topology).clone(),
         resolver: Arc::clone(&state.spec_resolver),
@@ -334,6 +343,7 @@ mod tests {
         OfferParams {
             sdp,
             bind_ip: std::net::Ipv4Addr::LOCALHOST,
+            advertise_ip: None,
             carrier_rate: WEBRTC_CARRIER_RATE,
             topology: TopologyConfig::Realtime {
                 provider: "gemini".into(),

--- a/flowcat-transports/src/webrtc/mod.rs
+++ b/flowcat-transports/src/webrtc/mod.rs
@@ -90,6 +90,9 @@ impl WebRtcTransport {
     ///   [`signaling::WebRtcPeer::accept_offer`]).
     /// - `socket` — an already-bound UDP socket for the WebRTC media (the caller
     ///   chooses the bind interface — security).
+    /// - `advertise_ip` — the IP to advertise in the host ICE candidate; `Some`
+    ///   decouples it from the bound addr (bind `0.0.0.0`, advertise a public IP),
+    ///   `None` advertises the bound addr.
     /// - `carrier_rate` — the pipeline-facing sample rate (e.g. 16000).
     ///
     /// Returns the transport and the **SDP answer** string to send back to the
@@ -98,9 +101,11 @@ impl WebRtcTransport {
     pub fn accept_offer(
         offer_sdp: &str,
         socket: tokio::net::UdpSocket,
+        advertise_ip: Option<std::net::IpAddr>,
         carrier_rate: u32,
     ) -> Result<(Self, String), FlowcatError> {
-        let (peer, answer_sdp, channels) = WebRtcPeer::accept_offer(offer_sdp, socket)?;
+        let (peer, answer_sdp, channels) =
+            WebRtcPeer::accept_offer(offer_sdp, socket, advertise_ip)?;
         let PeerChannels {
             inbound_rx,
             outbound_tx,
@@ -268,7 +273,7 @@ mod tests {
         // --- Our transport: bind a socket, accept the offer, get the answer. ---
         let our_socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let (mut transport, answer_sdp) =
-            WebRtcTransport::accept_offer(&offer_sdp, our_socket, 16000).expect("accept");
+            WebRtcTransport::accept_offer(&offer_sdp, our_socket, None, 16000).expect("accept");
         assert_eq!(transport.carrier_rate(), 16000);
 
         // Feed our answer back to the browser to complete negotiation.
@@ -424,7 +429,7 @@ mod tests {
 
         let our_socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let (mut transport, _answer) =
-            WebRtcTransport::accept_offer(&offer.to_sdp_string(), our_socket, 16000).unwrap();
+            WebRtcTransport::accept_offer(&offer.to_sdp_string(), our_socket, None, 16000).unwrap();
 
         let err = transport
             .send_audio(AudioChunk::new(vec![0i16; 160], 8000))

--- a/flowcat-transports/src/webrtc/signaling.rs
+++ b/flowcat-transports/src/webrtc/signaling.rs
@@ -45,7 +45,7 @@
 //!   be queued (consumer momentarily full) is dropped rather than stalling the
 //!   ICE/DTLS servicing loop.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -135,14 +135,18 @@ impl WebRtcPeer {
     /// - `offer_sdp` — the raw SDP offer text the browser POSTed. Length-capped
     ///   ([`MAX_OFFER_BYTES`]) and parsed defensively; a malformed/empty/oversized
     ///   offer yields [`FlowcatError::Protocol`] (never a panic).
-    /// - `socket` — an already-bound UDP socket; its local addr becomes our host
-    ///   ICE candidate. The caller chooses the bind interface (security).
+    /// - `socket` — an already-bound UDP socket. The caller chooses the bind
+    ///   interface (security).
+    /// - `advertise_ip` — the IP to put in the host ICE candidate. `Some` decouples
+    ///   the advertised address from the bound one (e.g. bind `0.0.0.0`, advertise a
+    ///   1:1-NAT public IP); `None` advertises the socket's own local addr.
     ///
     /// Returns the peer (drive it with [`run`](Self::run)) plus the answer SDP to
     /// hand back to the browser, and the [`PeerChannels`] for the transport.
     pub fn accept_offer(
         offer_sdp: &str,
         socket: UdpSocket,
+        advertise_ip: Option<IpAddr>,
     ) -> Result<(Self, String, PeerChannels), FlowcatError> {
         // SECURITY: cap before parse so a hostile oversized body can't blow up
         // the parser / memory.
@@ -165,13 +169,26 @@ impl WebRtcPeer {
             .local_addr()
             .map_err(|e| FlowcatError::Transport(format!("socket local_addr: {e}")))?;
 
+        // The advertised candidate addr: the explicit advertise IP at the bound
+        // port, else the bound addr itself.
+        let candidate_addr = match advertise_ip {
+            Some(ip) => SocketAddr::new(ip, local_addr.port()),
+            None => local_addr,
+        };
+        // str0m rejects a 0.0.0.0 host candidate; catch the misconfiguration
+        // (bound wildcard with no advertise IP) with a clear error, not a bad SDP.
+        if candidate_addr.ip().is_unspecified() {
+            return Err(FlowcatError::Transport(
+                "WebRTC host candidate would be 0.0.0.0; set an advertise IP when binding the wildcard".into(),
+            ));
+        }
+
         // Build the Rtc. str0m generates a fresh self-signed DTLS cert per Rtc,
         // resolves the crypto provider from feature flags, and leaves
         // `fingerprint_verification` ON (MITM guard) — we keep all defaults.
         let mut rtc = Rtc::new(Instant::now());
 
-        // Our single local host candidate is the bound UDP addr.
-        let candidate = Candidate::host(local_addr, "udp")
+        let candidate = Candidate::host(candidate_addr, "udp")
             .map_err(|e| FlowcatError::Transport(format!("host candidate: {e}")))?;
         rtc.add_local_candidate(candidate);
 
@@ -449,7 +466,8 @@ mod tests {
     async fn accept_offer_produces_valid_answer() {
         let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let offer = sample_browser_offer("127.0.0.1");
-        let (peer, answer, _ch) = WebRtcPeer::accept_offer(&offer, socket).expect("offer accepted");
+        let (peer, answer, _ch) =
+            WebRtcPeer::accept_offer(&offer, socket, None).expect("offer accepted");
 
         // We added our bound socket addr as the host candidate.
         assert_eq!(peer.local_addr().ip(), std::net::Ipv4Addr::LOCALHOST);
@@ -480,32 +498,69 @@ mod tests {
         // Empty.
         let s = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         assert!(matches!(
-            WebRtcPeer::accept_offer("", s),
+            WebRtcPeer::accept_offer("", s, None),
             Err(FlowcatError::Protocol(_))
         ));
 
         // Whitespace-only.
         let s = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         assert!(matches!(
-            WebRtcPeer::accept_offer("   \r\n  ", s),
+            WebRtcPeer::accept_offer("   \r\n  ", s, None),
             Err(FlowcatError::Protocol(_))
         ));
 
         // Garbage that is not SDP.
         let s = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        assert!(WebRtcPeer::accept_offer("this is not sdp at all", s).is_err());
+        assert!(WebRtcPeer::accept_offer("this is not sdp at all", s, None).is_err());
 
         // Truncated SDP (header only, no media). Must not panic — Ok or Err both
         // acceptable; reaching the next line proves no panic.
         let s = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let _ = WebRtcPeer::accept_offer("v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n", s);
+        let _ = WebRtcPeer::accept_offer("v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n", s, None);
 
         // Oversized body is capped before parse.
         let s = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let big = "v=0\r\n".to_string() + &"a=x\r\n".repeat(MAX_OFFER_BYTES);
         assert!(matches!(
-            WebRtcPeer::accept_offer(&big, s),
+            WebRtcPeer::accept_offer(&big, s, None),
             Err(FlowcatError::Protocol(_))
+        ));
+    }
+
+    /// With `advertise_ip = Some(public)`, the host ICE candidate in the answer
+    /// carries the **advertised** IP (at the bound port), not the bound socket addr
+    /// — the bind/advertise split that lets us bind 0.0.0.0 yet advertise a public
+    /// 1:1-NAT IP. (Mirrors the SIP path: bind UNSPECIFIED, advertise public_ip.)
+    #[tokio::test]
+    async fn advertise_ip_overrides_the_candidate_address() {
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let advertised = std::net::Ipv4Addr::new(203, 0, 113, 7);
+        let offer = sample_browser_offer("127.0.0.1");
+        let (_peer, answer, _ch) =
+            WebRtcPeer::accept_offer(&offer, socket, Some(IpAddr::V4(advertised)))
+                .expect("offer accepted");
+
+        // The answer's host candidate advertises the public IP, not 127.0.0.1.
+        assert!(
+            answer.contains("203.0.113.7"),
+            "answer advertises the configured IP: {answer}"
+        );
+        assert!(
+            !answer.contains("a=candidate") || !answer.contains("127.0.0.1 "),
+            "answer must not advertise the bound loopback addr: {answer}"
+        );
+    }
+
+    /// Binding the wildcard with no advertise IP would yield a 0.0.0.0 candidate,
+    /// which str0m rejects — we catch that misconfiguration with a clean error
+    /// instead of producing an invalid SDP.
+    #[tokio::test]
+    async fn wildcard_bind_without_advertise_ip_is_rejected() {
+        let socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let offer = sample_browser_offer("127.0.0.1");
+        assert!(matches!(
+            WebRtcPeer::accept_offer(&offer, socket, None),
+            Err(FlowcatError::Transport(_))
         ));
     }
 
@@ -516,7 +571,7 @@ mod tests {
         let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let offer = sample_browser_offer("127.0.0.1");
         let (mut peer, _answer, _ch) =
-            WebRtcPeer::accept_offer(&offer, socket).expect("offer accepted");
+            WebRtcPeer::accept_offer(&offer, socket, None).expect("offer accepted");
         let fake_source: SocketAddr = "127.0.0.1:5555".parse().unwrap();
         // A datagram that is neither STUN nor DTLS nor RTP.
         peer.handle_socket_input(&[0xFFu8, 0x00, 0x13, 0x37], fake_source);


### PR DESCRIPTION
## Problem

The WebRTC media path used a **single IP for two different jobs**:

- **bind** the media UDP socket — must be an address that is actually on the host's network interface, and
- **advertise** the host ICE candidate — the address the browser is told to send media to.

On a **1:1-NAT host (e.g. GKE)** the public IP is reachable from outside but is **not present on the node's NIC** (it's NAT-mapped). So binding it fails with `Cannot assign requested address` (errno 99) and the call never connects. On a plain VM the two are the same IP, which hid the bug.

## Fix

Separate **bind** from **advertise** — the exact pattern the SIP path already uses (bind `0.0.0.0`, advertise the configured public IP):

- `WebRtcPeer::accept_offer` / `WebRtcTransport::accept_offer` take an optional `advertise_ip`. The socket still binds its chosen interface; the host ICE candidate is built from `advertise_ip` when set, otherwise from the bound address (so **local behaviour is unchanged**).
- A guard rejects an **unspecified (`0.0.0.0`) candidate** (str0m would reject it anyway) — catches the "bind wildcard with no advertise IP" misconfiguration cleanly.
- `flowcat-server` resolves the advertise IP from `FLOWCAT_WEBRTC_ADVERTISE_IP`.

## Tests

- `advertise_ip_overrides_the_candidate_address` — bind loopback, advertise a different IP, assert the SDP answer carries the **advertised** IP, not the bound one.
- `wildcard_bind_without_advertise_ip_is_rejected` — the guard.
- Full transport webrtc suite green (12).