### PR TITLE
feat(flowcat-server): resolve SIP pipeline topology per-call

### DIFF
--- a/flowcat-server/src/lib.rs
+++ b/flowcat-server/src/lib.rs
@@ -65,7 +65,9 @@ pub use server::{build_router, AppState, BrainFactory};
 // The generic SIP inbound/originate orchestration — the SIP analogue of the
 // carrier media-WS path (`media_ws` + `run_call_with`).
 #[cfg(feature = "server-helper")]
-pub use sip::{serve_sip_inbound, sip_originate, SipInboundResolver, SipOrchestrator, SipRun};
+pub use sip::{
+    serve_sip_inbound, sip_originate, SipInboundResolver, SipOrchestrator, SipRun, TopologyResolver,
+};
 
 #[cfg(feature = "webrtc-helper")]
 pub use webrtc::{handle_offer, OfferParams};

--- a/flowcat-server/src/sip.rs
+++ b/flowcat-server/src/sip.rs
@@ -252,7 +252,7 @@ async fn handle_inbound_invite<S, B, R>(
     let (brain, topology) = match orchestrator.resolve_call(&run).await {
         Ok(resolved) => resolved,
         Err(e) => {
-            warn!(%call_id, run_id = run.run_id, error = %e, "SIP brain build rejected the INVITE");
+            warn!(%call_id, run_id = run.run_id, error = %e, "SIP call resolution rejected the INVITE");
             invite.reject(None);
             return;
         }
@@ -522,7 +522,7 @@ mod tests {
 
     /// Start a callee (running `serve_sip_inbound`) + a caller wired to dial it.
     async fn start_callee_and_caller<R>(
-        session: Arc<FakeSession>,
+        orchestrator: SipOrchestrator<FakeSession, EchoBrain>,
         inbound_resolver: Arc<R>,
     ) -> (Arc<SipAgent>, Arc<SipAgent>)
     where
@@ -532,7 +532,7 @@ mod tests {
         let callee = start_loopback_agent("sip:127.0.0.1:1".to_string(), port_callee).await;
         tokio::spawn(serve_sip_inbound(
             Arc::clone(&callee),
-            orchestrator(session),
+            orchestrator,
             inbound_resolver,
         ));
 
@@ -545,9 +545,11 @@ mod tests {
     #[tokio::test]
     async fn serve_sip_inbound_answers_a_resolved_invite() {
         let session = FakeSession::new("hi from the control plane");
-        let (callee, caller) =
-            start_callee_and_caller(Arc::clone(&session), Arc::new(AcceptInbound { run_id: 42 }))
-                .await;
+        let (callee, caller) = start_callee_and_caller(
+            orchestrator(Arc::clone(&session)),
+            Arc::new(AcceptInbound { run_id: 42 }),
+        )
+        .await;
 
         // The caller dials; `serve_sip_inbound` resolves → builds the brain → answers.
         // A returned media transport means the INVITE was answered (200 OK).
@@ -569,7 +571,8 @@ mod tests {
     async fn serve_sip_inbound_rejects_when_the_resolver_errs() {
         let session = FakeSession::new("unused");
         let (callee, caller) =
-            start_callee_and_caller(Arc::clone(&session), Arc::new(RejectInbound)).await;
+            start_callee_and_caller(orchestrator(Arc::clone(&session)), Arc::new(RejectInbound))
+                .await;
 
         // The resolver rejects (unknown DID) → the INVITE is rejected, so the caller's
         // originate fails (no media transport) rather than connecting.
@@ -579,6 +582,47 @@ mod tests {
         assert!(
             dialed.is_err(),
             "a rejected inbound INVITE must not yield a media transport"
+        );
+
+        caller.shutdown().await;
+        callee.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn serve_sip_inbound_rejects_when_the_topology_resolver_errs() {
+        // The per-call topology seam sits in the same pre-answer window as the brain,
+        // so a topology resolver that errs must fail the call *closed* — reject the
+        // INVITE rather than answer a call whose pipeline we can't build.
+        let session = FakeSession::new("unused");
+        let factory: BrainFactory<EchoBrain> = Arc::new(|resolved: &ResolvedCall| {
+            Ok(EchoBrain {
+                prompt: resolved.brain_config["prompt"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        });
+        let topology_resolver: TopologyResolver = Arc::new(|_: &ResolvedCall| {
+            Err(FlowcatError::Other("no topology for this run".into()))
+        });
+        let orchestrator = SipOrchestrator::with_topology_resolver(
+            Arc::clone(&session),
+            factory,
+            topology_resolver,
+            Arc::new(run::env_spec_resolver),
+        );
+
+        let (callee, caller) =
+            start_callee_and_caller(orchestrator, Arc::new(AcceptInbound { run_id: 42 })).await;
+
+        // The topology resolver errs → the INVITE is rejected, so the caller's
+        // originate fails (no media transport) rather than connecting.
+        let dialed = tokio::time::timeout(Duration::from_secs(5), caller.originate("2000", None))
+            .await
+            .expect("originate timed out");
+        assert!(
+            dialed.is_err(),
+            "a topology-resolver error must reject the INVITE, not answer it"
         );
 
         caller.shutdown().await;

--- a/flowcat-server/src/sip.rs
+++ b/flowcat-server/src/sip.rs
@@ -13,7 +13,8 @@
 //! already abstracts.
 //!
 //! This module is that loop, parameterised the same way the WS path is — over the
-//! embedder's [`SessionSource`] + a [`BrainFactory`] + a [`TopologyConfig`] + a
+//! embedder's [`SessionSource`] + a [`BrainFactory`] + a per-call [`TopologyResolver`]
+//! (or a static [`TopologyConfig`] for the standalone trunk) + a
 //! [`SpecResolver`] (bundled into [`SipOrchestrator`]) —
 //! plus one SIP-specific seam, [`SipInboundResolver`], that maps a dialed identifier
 //! to the run it should drive (the analogue of the run id + token the media-WS URL
@@ -36,7 +37,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::{error, info, warn};
 
-use flowcat_core::{AgentBrain, FlowcatError, InboundInvite, SessionSource, SipAgent};
+use flowcat_core::{
+    AgentBrain, FlowcatError, InboundInvite, ResolvedCall, SessionSource, SipAgent,
+};
 
 use crate::config::TopologyConfig;
 use crate::run::{self, SpecResolver};
@@ -71,8 +74,19 @@ pub trait SipInboundResolver: Send + Sync {
     async fn resolve_inbound(&self, invite: &InboundInvite) -> Result<SipRun, FlowcatError>;
 }
 
+/// Resolves a call's pipeline [`TopologyConfig`] from its [`ResolvedCall`] — the
+/// topology analogue of [`BrainFactory`], run over the *same* resolved call so an
+/// embedder can pin the pipeline mode/provider per run (realtime vs cascaded, a
+/// specific provider/model) from the resolved call's options, exactly as the brain
+/// is already chosen per-call. The WebRTC path takes the topology as a per-call
+/// parameter ([`OfferParams`](crate::webrtc::OfferParams)); this is how the SIP
+/// drivers reach the same per-call selection. The static-topology standalone case
+/// uses [`SipOrchestrator::new`], which wraps a constant in one of these.
+pub type TopologyResolver =
+    Arc<dyn Fn(&ResolvedCall) -> Result<TopologyConfig, FlowcatError> + Send + Sync>;
+
 /// The reusable per-trunk wiring both SIP drivers share: the embedder's session +
-/// per-call [`BrainFactory`] + pipeline [`TopologyConfig`] + provider-[`SpecResolver`].
+/// per-call [`BrainFactory`] + per-call [`TopologyResolver`] + provider-[`SpecResolver`].
 /// Mirrors the fields
 /// [`AppState`](crate::server::AppState) holds for the WS/WebRTC path, minus the
 /// HTTP-only bits. Cheap to clone (every field is an `Arc`), so each inbound call
@@ -80,7 +94,7 @@ pub trait SipInboundResolver: Send + Sync {
 pub struct SipOrchestrator<S, B> {
     session: Arc<S>,
     brain_factory: BrainFactory<B>,
-    topology: Arc<TopologyConfig>,
+    topology_resolver: TopologyResolver,
     resolver: SpecResolver,
 }
 
@@ -91,7 +105,7 @@ impl<S, B> Clone for SipOrchestrator<S, B> {
         Self {
             session: Arc::clone(&self.session),
             brain_factory: Arc::clone(&self.brain_factory),
-            topology: Arc::clone(&self.topology),
+            topology_resolver: Arc::clone(&self.topology_resolver),
             resolver: Arc::clone(&self.resolver),
         }
     }
@@ -102,8 +116,14 @@ where
     S: SessionSource + 'static,
     B: AgentBrain + 'static,
 {
-    /// Bundle the per-trunk wiring. `resolver` resolves each provider leg's spec
-    /// (keys): pass `Arc::new(run::env_spec_resolver)` to read keys from the env (the
+    /// Bundle the per-trunk wiring with a **single static** topology — the
+    /// standalone-server case, where one config-file [`TopologyConfig`] drives the
+    /// whole trunk. Wraps that constant in a [`TopologyResolver`] that ignores the
+    /// resolved call; use [`with_topology_resolver`](Self::with_topology_resolver) to
+    /// pick the topology per-call instead.
+    ///
+    /// `resolver` resolves each provider leg's spec (keys): pass
+    /// `Arc::new(run::env_spec_resolver)` to read keys from the env (the
     /// standalone-server convention), or an embedder's own secret-store lookup.
     pub fn new(
         session: Arc<S>,
@@ -111,21 +131,46 @@ where
         topology: TopologyConfig,
         resolver: SpecResolver,
     ) -> Self {
+        let topology = Arc::new(topology);
+        Self::with_topology_resolver(
+            session,
+            brain_factory,
+            Arc::new(move |_: &ResolvedCall| Ok((*topology).clone())),
+            resolver,
+        )
+    }
+
+    /// Bundle the per-trunk wiring, resolving the pipeline [`TopologyConfig`]
+    /// **per-call** from the [`ResolvedCall`] (the same resolved call the
+    /// [`BrainFactory`] runs over). Lets an embedder pin the pipeline mode/provider
+    /// per run — realtime vs cascaded, or a specific provider/model — from the
+    /// resolved call's options, bringing the SIP path to parity with the WebRTC
+    /// [`handle_offer`](crate::webrtc::handle_offer)'s per-call topology parameter.
+    pub fn with_topology_resolver(
+        session: Arc<S>,
+        brain_factory: BrainFactory<B>,
+        topology_resolver: TopologyResolver,
+        resolver: SpecResolver,
+    ) -> Self {
         Self {
             session,
             brain_factory,
-            topology: Arc::new(topology),
+            topology_resolver,
             resolver,
         }
     }
 
-    /// Resolve a run's brain through the session + factory (shared by both drivers).
+    /// Resolve a run's brain **and** pipeline topology through the session, factory,
+    /// and topology resolver (shared by both drivers).
     ///
+    /// One `session.resolve` feeds both the [`BrainFactory`] and the
+    /// [`TopologyResolver`], so the brain and topology are chosen from the *same*
+    /// [`ResolvedCall`] (no second round-trip, no chance of the two disagreeing).
     /// Mirrors the WS path's `resolve_brain` but returns a plain [`FlowcatError`]
     /// (SIP has no HTTP status to map to): a failed resolve, an already-completed
-    /// run, or a rejected graph all surface as `Err` so the caller fails the call
-    /// **closed** (rejects the INVITE / aborts the originate).
-    async fn resolve_brain(&self, run: &SipRun) -> Result<B, FlowcatError> {
+    /// run, or a rejected graph/topology all surface as `Err` so the caller fails the
+    /// call **closed** (rejects the INVITE / aborts the originate).
+    async fn resolve_call(&self, run: &SipRun) -> Result<(B, TopologyConfig), FlowcatError> {
         let resolved = self.session.resolve(run.run_id, &run.token).await?;
         if resolved.is_completed {
             return Err(FlowcatError::Other(format!(
@@ -133,7 +178,9 @@ where
                 run.run_id
             )));
         }
-        (self.brain_factory)(&resolved)
+        let brain = (self.brain_factory)(&resolved)?;
+        let topology = (self.topology_resolver)(&resolved)?;
+        Ok((brain, topology))
     }
 }
 
@@ -198,10 +245,12 @@ async fn handle_inbound_invite<S, B, R>(
         }
     };
 
-    // 2. Build the brain through the session + factory BEFORE answering, so a bad
-    //    resolve/graph rejects the INVITE rather than answering a call we can't run.
-    let brain = match orchestrator.resolve_brain(&run).await {
-        Ok(brain) => brain,
+    // 2. Build the brain + resolve the topology through the session/factory/resolver
+    //    BEFORE answering, so a bad resolve/graph/topology rejects the INVITE rather
+    //    than answering a call we can't run. Topology is resolved per-call from the
+    //    same ResolvedCall as the brain.
+    let (brain, topology) = match orchestrator.resolve_call(&run).await {
+        Ok(resolved) => resolved,
         Err(e) => {
             warn!(%call_id, run_id = run.run_id, error = %e, "SIP brain build rejected the INVITE");
             invite.reject(None);
@@ -224,7 +273,7 @@ async fn handle_inbound_invite<S, B, R>(
     let SipRun { run_id, token } = run;
     let res = run::run_call_with(
         transport,
-        &orchestrator.topology,
+        &topology,
         &*orchestrator.resolver,
         brain,
         Arc::clone(&orchestrator.session),
@@ -264,8 +313,10 @@ where
     S: SessionSource + 'static,
     B: AgentBrain + 'static,
 {
-    // Build the brain before dialing so a bad resolve/graph fails fast (no INVITE).
-    let brain = orchestrator.resolve_brain(&run).await?;
+    // Build the brain + resolve the topology before dialing so a bad
+    // resolve/graph/topology fails fast (no INVITE). Topology is resolved per-call
+    // from the same ResolvedCall as the brain.
+    let (brain, topology) = orchestrator.resolve_call(&run).await?;
 
     // Dial; returns once the callee answers (200 OK) with the media transport.
     let transport = agent.originate(dest, caller_id).await?;
@@ -276,7 +327,7 @@ where
     tokio::spawn(async move {
         let res = run::run_call_with(
             transport,
-            &orchestrator.topology,
+            &topology,
             &*orchestrator.resolver,
             brain,
             Arc::clone(&orchestrator.session),
@@ -582,5 +633,56 @@ mod tests {
         answer.await.expect("answer task panicked");
         caller.shutdown().await;
         callee.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn resolve_call_picks_topology_per_call_from_one_resolve() {
+        let session = FakeSession::new("hi from the control plane");
+        let factory: BrainFactory<EchoBrain> = Arc::new(|resolved: &ResolvedCall| {
+            Ok(EchoBrain {
+                prompt: resolved.brain_config["prompt"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        });
+        // A topology resolver that derives the topology from the resolved call (here:
+        // its provider) and counts its invocations, proving per-call selection.
+        let topo_calls = Arc::new(AtomicUsize::new(0));
+        let tc = Arc::clone(&topo_calls);
+        let topology_resolver: TopologyResolver = Arc::new(move |resolved: &ResolvedCall| {
+            tc.fetch_add(1, Ordering::SeqCst);
+            Ok(TopologyConfig::Realtime {
+                provider: resolved.provider.clone(),
+                model: String::new(),
+                options: Default::default(),
+            })
+        });
+        let orchestrator = SipOrchestrator::with_topology_resolver(
+            Arc::clone(&session),
+            factory,
+            topology_resolver,
+            Arc::new(run::env_spec_resolver),
+        );
+
+        let (brain, topology) = orchestrator
+            .resolve_call(&SipRun {
+                run_id: 1,
+                token: "tok".into(),
+            })
+            .await
+            .expect("resolve_call");
+
+        // Brain came from the resolved brain_config…
+        assert_eq!(brain.system_prompt(), "hi from the control plane");
+        // …and the topology was chosen per-call from the *same* ResolvedCall.
+        match topology {
+            TopologyConfig::Realtime { provider, .. } => assert_eq!(provider, "fake"),
+            other => panic!("expected the per-call realtime topology, got {other:?}"),
+        }
+        // Exactly one session.resolve fed both seams (no second round-trip), and the
+        // topology resolver ran once over that resolved call.
+        assert_eq!(session.resolves.load(Ordering::SeqCst), 1);
+        assert_eq!(topo_calls.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## What

Brings the SIP orchestration path to parity with WebRTC: the pipeline `TopologyConfig` is now resolved **per-call** from the `ResolvedCall`, mirroring how the brain is already chosen per-call via `BrainFactory`.

Previously `SipOrchestrator` baked in a single static trunk topology, so both SIP drivers (`serve_sip_inbound` / `sip_originate`) ran every call with the same `TopologyConfig`. An embedder could not pin the pipeline mode/provider per run (realtime vs cascaded, a specific provider/model) the way `handle_offer` already allows on the WebRTC path via `OfferParams.topology`.

Closes #35.

## How

- Add `TopologyResolver = Arc<dyn Fn(&ResolvedCall) -> Result<TopologyConfig, FlowcatError> + Send + Sync>` — the topology analogue of `BrainFactory`.
- `SipOrchestrator` now holds a `topology_resolver` instead of a static topology.
  - `new(...)` keeps its existing signature (static-trunk convenience) by wrapping the constant in a resolver.
  - `with_topology_resolver(...)` is the per-call constructor.
- `resolve_brain` → `resolve_call` returns `(brain, topology)` from a **single** `session.resolve`, so both seams see the same `ResolvedCall` (no second round-trip, no chance of the two disagreeing).
- `handle_inbound_invite` / `sip_originate` resolve the topology in the same pre-answer / pre-dial **fail-closed** window as the brain and pass it to `run_call_with`.

## Review fixes (second commit)

- Re-export `TopologyResolver` at the crate root next to `BrainFactory` (both `TopologyConfig` and `SpecResolver` were already there) so embedders can name it ergonomically.
- Reword the inbound reject log to "SIP call resolution rejected the INVITE" — `resolve_call` now also runs the topology resolver, so the error may be a topology failure, not a brain build.
- Add `serve_sip_inbound_rejects_when_the_topology_resolver_errs`, proving a topology-resolver error fails the call **closed** (rejects the INVITE) in the same pre-answer window.

## Tests

- New: `resolve_call_picks_topology_per_call_from_one_resolve` — proves per-call topology selection from a single `session.resolve`.
- New: `serve_sip_inbound_rejects_when_the_topology_resolver_errs` — fail-closed coverage for the new seam.
- `cargo test -p flowcat-server --features server-helper`, `cargo fmt --all --check`, and `cargo clippy -p flowcat-server --features server-helper --all-targets -- -D warnings` all pass. Default build stays dependency-free.