### PR TITLE
Implement assistant tool call tracking and result serialization for OpenAI compliance

### DIFF
--- a/flowcat-core/src/pipeline/cascaded.rs
+++ b/flowcat-core/src/pipeline/cascaded.rs
@@ -138,11 +138,40 @@ impl RollingContext {
         self.tools = tools;
     }
 
+    /// Record the `assistant` message that made a tool call, so the following
+    /// `tool` result has a valid preceding `tool_calls` to answer. OpenAI
+    /// chat-completions rejects a `tool` message that is not a response to a
+    /// prior assistant message carrying `tool_calls` (`400`: "a message with
+    /// role 'tool' must be a response to a preceding message with 'tool_calls'").
+    /// `arguments` is serialized to the JSON **string** the API expects.
+    fn push_assistant_tool_call(&mut self, tool_call_id: &str, name: &str, arguments: &Value) {
+        let arguments = match arguments {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        self.messages.push(json!({
+            "role": "assistant",
+            "content": Value::Null,
+            "tool_calls": [{
+                "id": tool_call_id,
+                "type": "function",
+                "function": { "name": name, "arguments": arguments },
+            }],
+        }));
+    }
+
     /// Append a workflow (MCP/HTTP) **tool result** to the rolling history as a
     /// `tool` message so the re-run LLM sees the result and continues the turn
-    /// (the cascaded analogue of the realtime `send_tool_result`). The content is
-    /// stored verbatim (a bare string, matching the brain's relay contract).
+    /// (the cascaded analogue of the realtime `send_tool_result`). OpenAI requires
+    /// a `tool` message's `content` to be a **string** (or array of content
+    /// parts); the brain relays the raw MCP result, which is usually a JSON object
+    /// (e.g. `{"departments": […]}`) — sending that verbatim 400s with
+    /// `invalid_type`. So a non-string result is serialized to a JSON string.
     fn push_tool_result(&mut self, tool_call_id: &str, content: &Value) {
+        let content = match content {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
         self.messages.push(json!({
             "role": "tool",
             "tool_call_id": tool_call_id,
@@ -754,11 +783,20 @@ struct CascadedToolBridge {
     /// The shared rolling LLM context (also held by the user/assistant aggregators),
     /// updated on transitions + tool results.
     ctx: SharedContext,
+    /// In-flight tool calls (`tool_call_id → (name, arguments)`), recorded when the
+    /// LLM emits [`Frame::FunctionCallsStarted`] and consumed when the matching
+    /// [`ToolResult`] returns — so the rolling context can record the
+    /// `assistant`+`tool_calls` turn OpenAI requires before the `tool` result.
+    /// Transition/end ACKs drop their entry without emitting a tool message.
+    pending: std::collections::HashMap<String, (String, Value)>,
 }
 
 impl CascadedToolBridge {
     fn new(ctx: SharedContext) -> Self {
-        Self { ctx }
+        Self {
+            ctx,
+            pending: std::collections::HashMap::new(),
+        }
     }
 }
 
@@ -776,6 +814,12 @@ impl FrameProcessor for CascadedToolBridge {
             // (don't forward it past the brain into the assistant aggregator / TTS).
             Frame::FunctionCallsStarted(calls) => {
                 for c in calls {
+                    // Track the call so its result can be paired into a valid
+                    // assistant→tool_calls→tool exchange when it returns.
+                    self.pending.insert(
+                        c.tool_call_id.clone(),
+                        (c.function_name.clone(), c.arguments.clone()),
+                    );
                     link.push_down(Frame::Custom(Arc::new(ModelToolCall {
                         id: c.tool_call_id.clone(),
                         name: c.function_name.clone(),
@@ -818,10 +862,21 @@ impl FrameProcessor for CascadedToolBridge {
                 if !is_transition_ack(&tr.result) {
                     let snapshot = {
                         let mut ctx = self.ctx.lock().unwrap();
+                        // Record the assistant `tool_calls` turn (if we tracked it)
+                        // so the tool result has a valid call to answer, then the
+                        // result itself, then re-run for the continuation.
+                        if let Some((name, args)) = self.pending.remove(&tr.id) {
+                            ctx.push_assistant_tool_call(&tr.id, &name, &args);
+                        }
                         ctx.push_tool_result(&tr.id, &tr.result);
                         ctx.snapshot()
                     };
                     link.push_up(Frame::LlmContext(Arc::new(snapshot))).await;
+                } else {
+                    // Transition/stay/end ACK — no `tool` message is appended (the
+                    // transition re-runs via its paired Reprompt); drop the tracked
+                    // call so it can't leave a dangling `tool_calls`.
+                    self.pending.remove(&tr.id);
                 }
             }
 
@@ -1998,5 +2053,50 @@ mod tests {
         assert!(!is_transition_ack(&json!({ "booking_id": "B1" })));
         assert!(!is_transition_ack(&json!({ "status": 200 })));
         assert!(!is_transition_ack(&json!("moved")));
+    }
+
+    // ---- tool-call exchange shape: the OpenAI chat-completions contract --------
+    // A `tool` message must (a) have STRING content and (b) follow an `assistant`
+    // message carrying matching `tool_calls`. The live cascaded bug was an object
+    // content (`400 invalid_type`) with no preceding `tool_calls`.
+
+    #[test]
+    fn tool_exchange_records_assistant_tool_call_then_string_result() {
+        let mut ctx = RollingContext::new(None, vec![]);
+        ctx.push_assistant_tool_call("call_1", "list_departments", &json!({ "q": "cardio" }));
+        ctx.push_tool_result("call_1", &json!({ "departments": ["cardiology"] }));
+        let snap = ctx.snapshot();
+
+        // (a) assistant turn records the tool call; arguments are a JSON STRING.
+        assert_eq!(snap.messages[0]["role"], "assistant");
+        assert_eq!(snap.messages[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(
+            snap.messages[0]["tool_calls"][0]["function"]["name"],
+            "list_departments"
+        );
+        assert!(
+            snap.messages[0]["tool_calls"][0]["function"]["arguments"].is_string(),
+            "OpenAI requires tool-call arguments to be a JSON string"
+        );
+
+        // (b) the tool result follows it with STRING content (object serialized).
+        assert_eq!(snap.messages[1]["role"], "tool");
+        assert_eq!(snap.messages[1]["tool_call_id"], "call_1");
+        assert!(
+            snap.messages[1]["content"].is_string(),
+            "object tool result must be serialized to a string, not sent as an object"
+        );
+        assert!(snap.messages[1]["content"]
+            .as_str()
+            .unwrap()
+            .contains("cardiology"));
+    }
+
+    #[test]
+    fn string_tool_result_passes_through_unchanged() {
+        let mut ctx = RollingContext::new(None, vec![]);
+        ctx.push_tool_result("call_2", &json!("already a string"));
+        let snap = ctx.snapshot();
+        assert_eq!(snap.messages[0]["content"], "already a string");
     }
 }

--- a/flowcat-core/src/pipeline/s2s.rs
+++ b/flowcat-core/src/pipeline/s2s.rs
@@ -61,6 +61,7 @@ use crate::brain::AgentBrain;
 use crate::codec::Resampler;
 use crate::error::{FlowcatError, Result};
 use crate::processor::frame::{AudioFrame, Frame, FrameClass, StartParams};
+use crate::processor::metrics::MetricsData;
 use crate::processor::{Envelope, FrameProcessor, Link, ProcessorSetup, StopReason};
 use crate::realtime::{RealtimeKickoff, RealtimeLlm};
 use crate::session::SessionSource;
@@ -1131,9 +1132,26 @@ impl FrameProcessor for RecorderProcessor {
                 self.state.lock().unwrap().recorder.push_inbound(&chunk);
             }
             // Usage report — fold into the shared LiveState (call.rs accumulate_usage).
+            // The realtime path emits this `Custom(UsageReport)` from its provider event.
             Frame::Custom(c) if c.as_any().is::<UsageReport>() => {
                 let u = c.as_any().downcast_ref::<UsageReport>().unwrap();
                 self.state.lock().unwrap().accumulate_usage(&u.0);
+            }
+            // The cascaded LLM leg reports token usage as `Frame::Metrics(LlmUsage)`
+            // (the OpenAI/`include_usage` trailing chunk). Fold the same way so a
+            // cascaded call's run gets non-zero input/output tokens, just like realtime.
+            Frame::Metrics(items) => {
+                for m in items {
+                    if let MetricsData::LlmUsage { tokens, .. } = m {
+                        let usage = Usage {
+                            input_tokens: Some(tokens.prompt_tokens),
+                            output_tokens: Some(tokens.completion_tokens),
+                            total_tokens: Some(tokens.total_tokens),
+                            extra: None,
+                        };
+                        self.state.lock().unwrap().accumulate_usage(&usage);
+                    }
+                }
             }
             _ => {}
         }

--- a/flowcat-services/src/llm/openai.rs
+++ b/flowcat-services/src/llm/openai.rs
@@ -23,6 +23,7 @@ use serde_json::{json, Value};
 
 use flowcat_core::error::{FlowcatError, Result};
 use flowcat_core::processor::frame::{Frame, FunctionCall, LlmContext, StartParams};
+use flowcat_core::processor::metrics::{LlmTokenUsage, MetricsData};
 use flowcat_core::service::{LlmService, Tool};
 
 /// OpenAI's default API base. A `base_url` override points the same client at
@@ -95,6 +96,9 @@ impl OpenAiLlm {
             "model": self.model,
             "messages": ctx.messages,
             "stream": true,
+            // Ask for the trailing usage chunk so the cascaded leg can report LLM
+            // token usage (parsed in `accumulate`, emitted as `Frame::Metrics`).
+            "stream_options": { "include_usage": true },
         });
         // Tools: prefer the context's, else the service-level set. OpenAI wants
         // each tool as `{ "type": "function", "function": { name, description,
@@ -159,7 +163,9 @@ impl LlmService for OpenAiLlm {
         // Build an owned byte stream so the returned frame stream does not borrow
         // `self` (only the connection/body, which the stream owns). The SSE
         // bytes are buffered line-by-line and mapped to frames as they arrive.
-        Ok(sse_to_frames(resp.bytes_stream()))
+        // The model name is cloned in so the trailing usage chunk can be reported
+        // as `Frame::Metrics(LlmUsage { model, … })`.
+        Ok(sse_to_frames(resp.bytes_stream(), self.model.clone()))
     }
 
     fn set_tools(&mut self, tools: Vec<Tool>) {
@@ -174,12 +180,18 @@ struct SseState {
     finished: bool,
     pending: std::collections::VecDeque<Frame>,
     tool_acc: BTreeMap<u64, ToolAcc>,
+    /// The model name, echoed into the emitted `LlmUsage` metric.
+    model: String,
+    /// Token usage from the trailing `{"usage": …}` chunk (present only when the
+    /// request set `stream_options.include_usage`). Emitted on [`finish`].
+    usage: Option<LlmTokenUsage>,
 }
 
 impl SseState {
     /// Flush the end-of-response frames into `pending` once: emit
     /// `LlmResponseStart` first if the stream produced nothing, then any
-    /// assembled tool calls (`FunctionCallsStarted`), then `LlmResponseEnd`.
+    /// assembled tool calls (`FunctionCallsStarted`), then the LLM token-usage
+    /// metric (if the trailing usage chunk arrived), then `LlmResponseEnd`.
     fn finish(&mut self) {
         if self.finished {
             return;
@@ -192,7 +204,37 @@ impl SseState {
         if let Some(f) = drain_tool_calls(&mut self.tool_acc) {
             self.pending.push_back(f);
         }
+        if let Some(tokens) = self.usage.take() {
+            self.pending
+                .push_back(Frame::Metrics(vec![MetricsData::LlmUsage {
+                    processor: "openai".to_string(),
+                    model: Some(self.model.clone()),
+                    tokens,
+                }]));
+        }
         self.pending.push_back(Frame::LlmResponseEnd);
+    }
+}
+
+/// Parse an OpenAI streaming `usage` object into [`LlmTokenUsage`]. The trailing
+/// chunk (when `stream_options.include_usage` is set) carries
+/// `{prompt_tokens, completion_tokens, total_tokens, …}` with an empty `choices`.
+fn parse_usage(usage: &Value) -> LlmTokenUsage {
+    let get = |k: &str| usage.get(k).and_then(Value::as_u64).unwrap_or(0);
+    let opt = |path: &[&str]| -> Option<u64> {
+        let mut cur = usage;
+        for k in path {
+            cur = cur.get(k)?;
+        }
+        cur.as_u64()
+    };
+    LlmTokenUsage {
+        prompt_tokens: get("prompt_tokens"),
+        completion_tokens: get("completion_tokens"),
+        total_tokens: get("total_tokens"),
+        cache_read_input_tokens: opt(&["prompt_tokens_details", "cached_tokens"]),
+        cache_creation_input_tokens: None,
+        reasoning_tokens: opt(&["completion_tokens_details", "reasoning_tokens"]),
     }
 }
 
@@ -201,7 +243,7 @@ impl SseState {
 /// `LlmResponseEnd`. Owns the body stream so it doesn't borrow the service.
 /// Generic over the chunk type (`AsRef<[u8]>`) so we don't name `bytes::Bytes`
 /// (no extra dep).
-fn sse_to_frames<S, B, E>(byte_stream: S) -> BoxStream<'static, Frame>
+fn sse_to_frames<S, B, E>(byte_stream: S, model: String) -> BoxStream<'static, Frame>
 where
     S: futures::Stream<Item = std::result::Result<B, E>> + Send + 'static,
     B: AsRef<[u8]> + Send + 'static,
@@ -214,6 +256,8 @@ where
         finished: false,
         pending: std::collections::VecDeque::new(),
         tool_acc: BTreeMap::new(),
+        model,
+        usage: None,
     };
     stream::unfold((inner, st), |(mut inner, mut st)| async move {
         loop {
@@ -237,6 +281,12 @@ where
                                 if !st.started {
                                     st.started = true;
                                     st.pending.push_back(Frame::LlmResponseStart);
+                                }
+                                // The trailing `include_usage` chunk carries a
+                                // top-level `usage` (and an empty `choices`); stash
+                                // it to emit on finish.
+                                if let Some(u) = v.get("usage").filter(|u| !u.is_null()) {
+                                    st.usage = Some(parse_usage(u));
                                 }
                                 accumulate(&v, &mut st.tool_acc, &mut st.pending);
                             }
@@ -479,6 +529,66 @@ mod tests {
             }
             other => panic!("expected FunctionCallsStarted, got {}", other.name()),
         }
+    }
+
+    #[test]
+    fn request_body_asks_for_include_usage() {
+        let llm = OpenAiLlm::new("k");
+        let ctx = LlmContext {
+            messages: vec![json!({"role": "user", "content": "hi"})],
+            tools: vec![],
+        };
+        let body = llm.request_body(&ctx);
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn parse_usage_maps_openai_token_fields() {
+        let u = json!({
+            "prompt_tokens": 12, "completion_tokens": 7, "total_tokens": 19,
+            "prompt_tokens_details": { "cached_tokens": 4 },
+            "completion_tokens_details": { "reasoning_tokens": 3 }
+        });
+        let t = parse_usage(&u);
+        assert_eq!(t.prompt_tokens, 12);
+        assert_eq!(t.completion_tokens, 7);
+        assert_eq!(t.total_tokens, 19);
+        assert_eq!(t.cache_read_input_tokens, Some(4));
+        assert_eq!(t.reasoning_tokens, Some(3));
+    }
+
+    #[tokio::test]
+    async fn sse_stream_emits_llm_usage_metric_from_trailing_chunk() {
+        // A text delta, then the `include_usage` trailing chunk (empty `choices`,
+        // top-level `usage`), then `[DONE]`. The cascaded leg must surface the
+        // usage as `Frame::Metrics(LlmUsage)` so the run records tokens.
+        let chunks: Vec<std::result::Result<Vec<u8>, std::convert::Infallible>> = vec![
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n".to_vec()),
+            Ok(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":7,\"total_tokens\":19}}\n".to_vec()),
+            Ok(b"data: [DONE]\n".to_vec()),
+        ];
+        let mut frames = sse_to_frames(stream::iter(chunks), "gpt-4o".to_string());
+        let mut saw_text = false;
+        let mut usage = None;
+        while let Some(f) = frames.next().await {
+            match f {
+                Frame::LlmText(_) => saw_text = true,
+                Frame::Metrics(items) => {
+                    for m in items {
+                        if let MetricsData::LlmUsage { model, tokens, .. } = m {
+                            usage = Some((model, tokens));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_text, "text delta still streams");
+        let (model, tokens) = usage.expect("a usage metric is emitted");
+        assert_eq!(model.as_deref(), Some("gpt-4o"));
+        assert_eq!(tokens.prompt_tokens, 12);
+        assert_eq!(tokens.completion_tokens, 7);
+        assert_eq!(tokens.total_tokens, 19);
     }
 
     /// Live smoke (requires `OPENAI_API_KEY`): stream a one-token reply. Run:


### PR DESCRIPTION
1. Invalid tool-call message exchange

When the model in a cascaded turn calls a function, the result is fed back and the LLM is re-run. Two things made the reconstructed OpenAI messages array invalid:

- Tool result content was a raw JSON value. RollingContext::push_tool_result stored the brain's tool result (commonly a JSON object, e.g. {"items": [...]}) directly as the tool message's content. OpenAI chat-completions requires a tool message's content to be a string (or array of content parts); a bare object is rejected with:
▎ 400 invalid_type: Invalid type for 'messages[N].content': expected one of a string or array of objects, but got an object instead.
- The assistant tool_calls turn was never recorded. When the LLM emitted FunctionCallsStarted, the bridge forwarded it to the brain but never appended an assistant message carrying tool_calls to the rolling context (the assistant aggregator only appends spoken text, and a tool-call turn often has none). OpenAI requires a tool message to follow an assistant message with a matching tool_calls entry, otherwise it rejects the request. The content-type error above just happened to surface first.

Result: cascaded calls worked until the first tool call, then every subsequent turn failed. The realtime (s2s) path is unaffected because the realtime model keeps conversation + tool state server-side, so flowcat never reconstructs the messages array there.

2. No LLM token usage on the cascaded leg

OpenAiLlm requested a stream without stream_options.include_usage and never parsed a usage chunk, so it emitted no usage frame. The shared usage collector (RecorderProcessor) only folded the realtime path's usage report, so a cascaded run's accumulated Usage stayed at default (no input/output tokens).

Changes

flowcat-core/src/pipeline/cascaded.rs
- RollingContext::push_tool_result now serializes a non-string tool result to a JSON string (string results pass through unchanged).
- New RollingContext::push_assistant_tool_call records the assistant + tool_calls message (arguments serialized to the JSON string OpenAI expects).
- CascadedToolBridge now tracks in-flight calls (tool_call_id → {name, arguments}) on FunctionCallsStarted, and on the matching tool result appends a proper assistant → tool_calls → tool exchange before re-running. Internal transition/end ACKs are excluded, so they never leave a dangling tool_calls.

flowcat-services/src/llm/openai.rs
- Request body sets stream_options: { include_usage: true }.
- The SSE parser captures the trailing usage chunk and emits Frame::Metrics(MetricsData::LlmUsage { model, tokens }) on stream finish (incl. cached/reasoning token detail when present).

flowcat-core/src/pipeline/s2s.rs
- RecorderProcessor now folds Frame::Metrics(LlmUsage) into the shared Usage totals — the same accumulator the realtime path feeds — so cascaded runs report input/output tokens too.