### PR TITLE
Feat/metrics fix

### DIFF
--- a/flowcat-core/src/observer/mod.rs
+++ b/flowcat-core/src/observer/mod.rs
@@ -363,6 +363,7 @@ fn metric_processor(d: &MetricsData) -> &str {
         | MetricsData::Processing { processor, .. }
         | MetricsData::LlmUsage { processor, .. }
         | MetricsData::TtsUsage { processor, .. }
+        | MetricsData::SttUsage { processor, .. }
         | MetricsData::TurnPrediction { processor, .. } => processor,
     }
 }

--- a/flowcat-core/src/observer/rtvi.rs
+++ b/flowcat-core/src/observer/rtvi.rs
@@ -506,8 +506,9 @@ fn map_metrics(data: &[MetricsData]) -> Option<RtviMessage> {
                 processor,
                 characters: chars,
             } => characters.push(json!({ "processor": processor, "value": chars })),
-            // Turn-prediction has no RTVI metrics bucket in pipecat — skip.
-            MetricsData::TurnPrediction { .. } => {}
+            // No RTVI metrics bucket for these in pipecat — skip (STT seconds is a
+            // billing metric folded by the recorder, not an RTVI stream value).
+            MetricsData::SttUsage { .. } | MetricsData::TurnPrediction { .. } => {}
         }
     }
 

--- a/flowcat-core/src/pipeline/s2s.rs
+++ b/flowcat-core/src/pipeline/s2s.rs
@@ -198,6 +198,14 @@ pub(crate) struct LiveState {
     /// Count of REAL workflow tool calls relayed this call (not transitions) —
     /// reported as `usage_metrics.tool_calls` for the Run-detail "Tool Calls" metric.
     pub(crate) tool_calls: u64,
+    /// Characters synthesized by the cascaded TTS leg this call, summed across
+    /// utterances. Surfaced flat as `usage_metrics.tts_characters`; the control
+    /// plane wraps it under the TTS `provider|||model` and prices it per-1k-chars.
+    tts_characters: u64,
+    /// Audio seconds fed to the cascaded STT leg this call. Surfaced flat as
+    /// `usage_metrics.stt_audio_seconds`; the control plane wraps it under the STT
+    /// `provider|||model` and prices it per-minute.
+    stt_audio_seconds: f64,
     error: Option<FlowcatError>,
     /// Set once a terminal transport error is seen (peer gone). De-dupes the log
     /// (warn once, not per buffered frame) and lets the sink stop sending / end the call.
@@ -213,6 +221,8 @@ impl LiveState {
             collected_vars: serde_json::Value::Null,
             usage: Usage::default(),
             tool_calls: 0,
+            tts_characters: 0,
+            stt_audio_seconds: 0.0,
             error: None,
             transport_dead: false,
         }
@@ -260,6 +270,21 @@ impl LiveState {
                 .or_insert_with(|| serde_json::json!(self.transcript.bot_turns()));
             map.entry("tool_calls".to_string())
                 .or_insert_with(|| serde_json::json!(self.tool_calls));
+            // Cascaded TTS characters synthesized (flat) — the control plane wraps
+            // this under the TTS provider|||model and prices it. Omitted when none
+            // (realtime has no separate TTS leg).
+            if self.tts_characters > 0 {
+                map.entry("tts_characters".to_string())
+                    .or_insert_with(|| serde_json::json!(self.tts_characters));
+            }
+            // Cascaded STT audio seconds (flat, rounded) — wrapped + priced per-minute
+            // by the control plane. Omitted when none (realtime has no separate STT leg).
+            if self.stt_audio_seconds > 0.0 {
+                map.entry("stt_audio_seconds".to_string())
+                    .or_insert_with(|| {
+                        serde_json::json!((self.stt_audio_seconds * 100.0).round() / 100.0)
+                    });
+            }
         }
         v
     }
@@ -1142,14 +1167,25 @@ impl FrameProcessor for RecorderProcessor {
             // cascaded call's run gets non-zero input/output tokens, just like realtime.
             Frame::Metrics(items) => {
                 for m in items {
-                    if let MetricsData::LlmUsage { tokens, .. } = m {
-                        let usage = Usage {
-                            input_tokens: Some(tokens.prompt_tokens),
-                            output_tokens: Some(tokens.completion_tokens),
-                            total_tokens: Some(tokens.total_tokens),
-                            extra: None,
-                        };
-                        self.state.lock().unwrap().accumulate_usage(&usage);
+                    match m {
+                        MetricsData::LlmUsage { tokens, .. } => {
+                            let usage = Usage {
+                                input_tokens: Some(tokens.prompt_tokens),
+                                output_tokens: Some(tokens.completion_tokens),
+                                total_tokens: Some(tokens.total_tokens),
+                                extra: None,
+                            };
+                            self.state.lock().unwrap().accumulate_usage(&usage);
+                        }
+                        // Cascaded TTS leg reports synthesized characters → cost.
+                        MetricsData::TtsUsage { characters, .. } => {
+                            self.state.lock().unwrap().tts_characters += characters;
+                        }
+                        // Cascaded STT leg reports audio seconds transcribed → cost.
+                        MetricsData::SttUsage { audio_seconds, .. } => {
+                            self.state.lock().unwrap().stt_audio_seconds += audio_seconds;
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -2034,11 +2070,24 @@ mod tests {
             total_tokens: Some(6),
             extra: Some(json!({ "cached": 3 })),
         });
+        // No TTS/STT usage yet → the cost keys are omitted (not a misleading 0).
+        assert!(st.usage_json().get("tts_characters").is_none());
+        assert!(st.usage_json().get("stt_audio_seconds").is_none());
         // Run-detail observability counts ride in the same usage object.
         st.transcript.push_user("hi");
         st.transcript.push_bot("hello");
         st.tool_calls = 2;
+        st.tts_characters = 137; // cascaded TTS leg synthesized 137 chars
+        st.stt_audio_seconds = 42.555; // cascaded STT transcribed 42.555s of audio
         let u = st.usage_json();
+        assert_eq!(
+            u["tts_characters"], 137,
+            "synthesized chars surfaced for billing"
+        );
+        assert_eq!(
+            u["stt_audio_seconds"], 42.56,
+            "audio seconds surfaced (2dp)"
+        );
         assert_eq!(u["input_tokens"], 15);
         assert_eq!(u["output_tokens"], 3);
         assert_eq!(u["total_tokens"], 18);

--- a/flowcat-core/src/processor/metrics.rs
+++ b/flowcat-core/src/processor/metrics.rs
@@ -31,6 +31,11 @@ pub enum MetricsData {
     },
     /// TTS character usage (`metrics.py:78`).
     TtsUsage { processor: String, characters: u64 },
+    /// STT audio usage — seconds of audio transcribed (billed per-minute).
+    SttUsage {
+        processor: String,
+        audio_seconds: f64,
+    },
     /// End-of-turn prediction metric (`metrics.py:101`).
     TurnPrediction {
         processor: String,

--- a/flowcat-core/src/service/adapters.rs
+++ b/flowcat-core/src/service/adapters.rs
@@ -48,6 +48,7 @@ use tokio::sync::Mutex;
 
 use crate::error::Result;
 use crate::processor::frame::{Frame, LlmContext, ServiceKind, StartParams};
+use crate::processor::metrics::MetricsData;
 use crate::processor::{Envelope, FrameProcessor, Link, ProcessorSetup};
 use crate::service::{LlmService, SttService, TtsService};
 
@@ -62,6 +63,10 @@ pub struct SttProcessor<S: SttService> {
     /// The wrapped STT service (shared so a provider impl can also drive its own
     /// internal streaming reader from the same handle).
     svc: Arc<Mutex<S>>,
+    /// Audio seconds forwarded to STT since the last `SttUsage` flush. Flushed
+    /// each ~1s as a `Frame::Metrics(SttUsage)` so the recorder can fold it into
+    /// `usage_metrics` for per-minute billing.
+    pending_audio_seconds: f64,
 }
 
 impl<S: SttService> SttProcessor<S> {
@@ -69,6 +74,7 @@ impl<S: SttService> SttProcessor<S> {
     pub fn new(svc: S) -> Self {
         Self {
             svc: Arc::new(Mutex::new(svc)),
+            pending_audio_seconds: 0.0,
         }
     }
 }
@@ -92,6 +98,19 @@ impl<S: SttService + 'static> FrameProcessor for SttProcessor<S> {
     async fn process_frame(&mut self, env: Envelope, link: &Link) -> Result<()> {
         match &env.frame {
             Frame::InputAudio(audio) => {
+                // Accrue the audio duration fed to STT (the billable basis for
+                // per-minute streaming STT); flush as an `SttUsage` metric each ~1s.
+                let channels = audio.num_channels.max(1) as f64;
+                self.pending_audio_seconds +=
+                    audio.pcm.len() as f64 / channels / audio.sample_rate.max(1) as f64;
+                if self.pending_audio_seconds >= 1.0 {
+                    link.push_down(Frame::Metrics(vec![MetricsData::SttUsage {
+                        processor: "stt".to_string(),
+                        audio_seconds: self.pending_audio_seconds,
+                    }]))
+                    .await;
+                    self.pending_audio_seconds = 0.0;
+                }
                 // Bounded round-trip: the (streaming) provider impl returns whatever
                 // its internal reader has decoded. Await it so the produced frames
                 // are enqueued downstream in order before the next frame is handled.
@@ -258,6 +277,15 @@ impl<T: TtsService> TtsProcessor<T> {
         match frames {
             Ok(frames) => {
                 tracing::debug!(frames = frames.len(), "cascaded TTS produced frames");
+                // Report characters synthesized for cost accounting. Count Unicode
+                // chars (not byte len) so multilingual text (Hindi/Telugu) bills
+                // correctly. Emitted only on success (a failed synth bills nothing);
+                // folded by the recorder into usage_metrics, priced per-1k-chars.
+                link.push_down(Frame::Metrics(vec![MetricsData::TtsUsage {
+                    processor: "tts".to_string(),
+                    characters: text.chars().count() as u64,
+                }]))
+                .await;
                 for f in frames {
                     let f = match f {
                         // Map TtsAudio → OutputAudio so a transport-out sink plays it.

--- a/flowcat-services/src/observability/otel.rs
+++ b/flowcat-services/src/observability/otel.rs
@@ -241,6 +241,16 @@ fn metric_span(d: &MetricsData) -> OtelSpan {
                 KeyValue::new("turn.e2e_processing_ms", *e2e_processing_ms),
             ],
         ),
+        MetricsData::SttUsage {
+            processor,
+            audio_seconds,
+        } => OtelSpan::new(
+            "metrics.stt_usage",
+            vec![
+                KeyValue::new("processor", processor.clone()),
+                KeyValue::new("metrics.audio_seconds", *audio_seconds),
+            ],
+        ),
     }
 }
 


### PR DESCRIPTION
Adds speech-to-text (STT) audio usage tracking to the flowcat pipeline so cascaded calls can be billed for transcription time, and wires TTS character usage through the same metrics path. Both metrics are accrued during the call and surfaced in the run's usage_metrics for the control plane to price — STT per-minute of audio, TTS per-1k-characters.
- New metric type — adds MetricsData::SttUsage { processor, audio_seconds } alongside the existing TtsUsage/LlmUsage variants (processor/metrics.rs), representing seconds of audio transcribed (the billable basis for per-minute streaming STT).
- STT accrual & flush — SttProcessor now sums the duration of each InputAudio frame fed to STT (correctly dividing by channels × sample-rate) and flushes it downstream as an SttUsage metric roughly once per second (service/adapters.rs).
- TTS reporting — TtsProcessor now emits TtsUsage on successful synthesis, counting Unicode characters (not byte length) so multilingual text (Hindi/Telugu) bills correctly; a failed synth bills nothing.
- Recorder folds both into the run — RecorderProcessor accumulates tts_characters and stt_audio_seconds per call and surfaces them flat in usage_metrics (pipeline/s2s.rs). The control plane wraps each under its provider|||model and prices it. Keys are omitted when zero (e.g., realtime/S2S has no separate STT/TTS leg) so you never get a misleading 0.
- RTVI observer — SttUsage is explicitly skipped in the RTVI stream (it's a billing metric folded by the recorder, not a live RTVI stream value), and added to the observer's processor-name mapping.