### PR TITLE
feat(sarvam): enhance STT and TTS with model and language options support

### DIFF
--- a/flowcat-services/src/factory.rs
+++ b/flowcat-services/src/factory.rs
@@ -176,7 +176,19 @@ pub fn stt(spec: &ProviderSpec) -> Result<Box<dyn SttService>, FlowcatError> {
             }))
         }
         #[cfg(feature = "stt-sarvam")]
-        "sarvam" => Ok(Box::new(crate::stt::SarvamStt::new(key))),
+        "sarvam" => {
+            // Honor the pinned model (`saarika:v2.5` vs `saaras:v2.5`) and the
+            // `language` option (BCP-47, e.g. `hi-IN`; absent → auto-detect).
+            let mut c = crate::stt::SarvamStt::new(key);
+            if !spec.model.is_empty() {
+                c = c.model(&spec.model);
+            }
+            let language = spec.opt("language");
+            if !language.is_empty() {
+                c = c.language(language);
+            }
+            Ok(Box::new(c))
+        }
         #[cfg(feature = "stt-openai")]
         "openai" | "whisper" => Ok(Box::new(crate::stt::OpenAiStt::new(key))),
         #[cfg(feature = "stt-groq")]
@@ -277,7 +289,22 @@ pub fn tts(spec: &ProviderSpec) -> Result<Box<dyn TtsService>, FlowcatError> {
         #[cfg(feature = "tts-openai")]
         "openai" => Ok(Box::new(crate::tts::OpenAiTts::new(key, voice))),
         #[cfg(feature = "tts-sarvam")]
-        "sarvam" => Ok(Box::new(crate::tts::SarvamTts::new(key, voice))),
+        "sarvam" => {
+            // `spec.model` is the voice (speaker); the actual Bulbul model and
+            // the `target_language_code` ride as options (`model`, `language`) —
+            // Sarvam rejects synthesis without a real language code, so the
+            // caller should pass one (default `en-IN`).
+            let mut c = crate::tts::SarvamTts::new(key, voice);
+            let model = spec.opt("model");
+            if !model.is_empty() {
+                c = c.model(model);
+            }
+            let language = spec.opt("language");
+            if !language.is_empty() {
+                c = c.language(language);
+            }
+            Ok(Box::new(c))
+        }
         #[cfg(feature = "tts-hume")]
         "hume" => Ok(Box::new(crate::tts::HumeTts::new(key, voice))),
         #[cfg(feature = "tts-inworld")]
@@ -651,6 +678,24 @@ mod tests {
             Err(e) => e.to_string(),
         };
         assert!(err.contains("no llm provider configured"), "got: {err}");
+    }
+
+    #[test]
+    #[cfg(all(feature = "stt-sarvam", feature = "tts-sarvam"))]
+    fn sarvam_builds_with_and_without_model_language_options() {
+        // Bare spec (host defaults: saarika:v2.5 / bulbul:v2 / en-IN).
+        assert!(stt(&spec("sarvam", "k")).is_ok());
+        assert!(tts(&spec("sarvam", "k")).is_ok());
+        // Pinned model + language options (the vaais Models-page path).
+        let s = spec("sarvam", "k")
+            .with_model("saaras:v2.5")
+            .with_option("language", "hi-IN");
+        assert!(stt(&s).is_ok());
+        let t = spec("sarvam", "k")
+            .with_model("anushka") // TTS spec.model = the voice id
+            .with_option("model", "bulbul:v3")
+            .with_option("language", "hi-IN");
+        assert!(tts(&t).is_ok());
     }
 
     #[test]

--- a/flowcat-services/src/stt/sarvam.rs
+++ b/flowcat-services/src/stt/sarvam.rs
@@ -7,8 +7,10 @@
 //! calls and, once a segment's worth has accumulated, wraps it in a WAV file and
 //! POSTs it as `multipart/form-data` to `https://api.sarvam.ai/speech-to-text`
 //! with an `api-subscription-key: <api-key>` header and the form fields `model`
-//! (default `saarika:v2.5`) + `language_code`. The JSON response is decoded by
-//! the **pure** [`decode_response`]:
+//! (default `saarika:v2.5`) + `language_code`. The `saaras:*` models (transcribe +
+//! translate) post to `/speech-to-text-translate` instead, without a
+//! `language_code` (that route auto-detects and translates to English). The JSON
+//! response is decoded by the **pure** [`decode_response`]:
 //!
 //! ```json
 //! { "transcript": "नमस्ते", "language_code": "hi-IN" }
@@ -35,6 +37,20 @@ use rest::{multipart_body, Part, SegmentBuffer};
 /// Sarvam's fixed STT endpoint. The **host is fixed**; the API key travels only
 /// in the `api-subscription-key` header, never in the URL.
 pub const SARVAM_STT_URL: &str = "https://api.sarvam.ai/speech-to-text";
+
+/// Sarvam's transcribe-and-translate endpoint — the `saaras:*` models are served
+/// here, not at the plain STT route (same host-is-fixed rule).
+pub const SARVAM_STT_TRANSLATE_URL: &str = "https://api.sarvam.ai/speech-to-text-translate";
+
+/// Endpoint for a model id: `saaras:*` (transcribe + translate) posts to the
+/// translate route; everything else (`saarika:*`) to plain speech-to-text.
+fn endpoint_for(model: &str) -> &'static str {
+    if model.starts_with("saaras") {
+        SARVAM_STT_TRANSLATE_URL
+    } else {
+        SARVAM_STT_URL
+    }
+}
 
 /// Seconds of audio buffered per POSTed segment.
 const SEGMENT_SECS: f32 = 5.0;
@@ -87,15 +103,20 @@ impl SarvamStt {
             return Ok(vec![]);
         };
         let boundary = "----flowcatSarvamBoundary7MA4YWxkTrZu0gW";
-        let parts = vec![
+        let url = endpoint_for(&self.model);
+        let mut parts = vec![
             Part::file("file", "audio.wav", "audio/x-wav", wav),
             Part::text("model", self.model.clone()),
-            Part::text("language_code", self.language.clone()),
         ];
+        // The translate route auto-detects the source language (output is
+        // English); `language_code` is a plain-STT-only field.
+        if url == SARVAM_STT_URL {
+            parts.push(Part::text("language_code", self.language.clone()));
+        }
         let (content_type, body) = multipart_body(boundary, &parts);
         let client = reqwest::Client::new();
         let resp = client
-            .post(SARVAM_STT_URL)
+            .post(url)
             .header("api-subscription-key", &self.api_key)
             .header("Content-Type", content_type)
             .body(body)
@@ -176,6 +197,17 @@ pub(crate) fn decode_response(body: &Value) -> Vec<Frame> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn saaras_models_route_to_the_translate_endpoint() {
+        assert_eq!(endpoint_for("saarika:v2.5"), SARVAM_STT_URL);
+        assert_eq!(endpoint_for("saaras:v2"), SARVAM_STT_TRANSLATE_URL);
+        assert_eq!(
+            endpoint_for(""),
+            SARVAM_STT_URL,
+            "empty model = default saarika"
+        );
+    }
 
     #[test]
     fn decode_transcript_response() {

--- a/flowcat-services/src/tts/sarvam.rs
+++ b/flowcat-services/src/tts/sarvam.rs
@@ -106,13 +106,15 @@ impl TtsService for SarvamTts {
     async fn run_tts(&mut self, text: &str) -> Result<Vec<Frame>> {
         self.ctx_counter += 1;
         let context_id: Arc<str> = Arc::from(format!("ctx-{}", self.ctx_counter));
-        let body = build_body(
-            text,
-            &self.language,
-            &self.speaker,
-            &self.model,
-            self.sample_rate,
-        );
+        // `auto` resolves the target language PER UTTERANCE from the text's
+        // script (Sarvam's API itself has no auto-detect) — one session can
+        // speak Tamil, Hindi, and English replies back-to-back.
+        let language = if self.language == "auto" {
+            language_for_text(text)
+        } else {
+            self.language.as_str()
+        };
+        let body = build_body(text, language, &self.speaker, &self.model, self.sample_rate);
         let req = HttpTtsRequest {
             url: self.url(),
             headers: vec![("api-subscription-key".to_string(), self.api_key.clone())],
@@ -121,6 +123,43 @@ impl TtsService for SarvamTts {
         let raw = self.client.post(req).await?;
         let pcm = decode_response(&raw);
         Ok(tts_frames(pcm, self.sample_rate, context_id))
+    }
+}
+
+/// Pick the Bulbul `target_language_code` for an utterance from its dominant
+/// Indic script (pure seam; used when the service language is `auto`).
+///
+/// Counts characters per Unicode block and returns the majority script's code;
+/// text with no Indic characters (Latin, digits, punctuation) → `en-IN`.
+/// Devanagari maps to `hi-IN` — Marathi shares the script and cannot be told
+/// apart without a language model, so `auto` speakers reading Marathi should pin
+/// `mr-IN` instead.
+pub fn language_for_text(text: &str) -> &'static str {
+    // (block-range, code) per Bulbul-supported script.
+    const BLOCKS: &[(std::ops::RangeInclusive<u32>, &str)] = &[
+        (0x0900..=0x097F, "hi-IN"), // Devanagari (Hindi/Marathi)
+        (0x0980..=0x09FF, "bn-IN"), // Bengali
+        (0x0A00..=0x0A7F, "pa-IN"), // Gurmukhi (Punjabi)
+        (0x0A80..=0x0AFF, "gu-IN"), // Gujarati
+        (0x0B00..=0x0B7F, "od-IN"), // Odia
+        (0x0B80..=0x0BFF, "ta-IN"), // Tamil
+        (0x0C00..=0x0C7F, "te-IN"), // Telugu
+        (0x0C80..=0x0CFF, "kn-IN"), // Kannada
+        (0x0D00..=0x0D7F, "ml-IN"), // Malayalam
+    ];
+    let mut counts = [0usize; 9];
+    for c in text.chars() {
+        let cp = c as u32;
+        for (i, (range, _)) in BLOCKS.iter().enumerate() {
+            if range.contains(&cp) {
+                counts[i] += 1;
+                break;
+            }
+        }
+    }
+    match counts.iter().enumerate().max_by_key(|(_, &n)| n) {
+        Some((i, &n)) if n > 0 => BLOCKS[i].1,
+        _ => "en-IN",
     }
 }
 
@@ -163,6 +202,25 @@ pub fn decode_response(body: &[u8]) -> Vec<i16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn language_for_text_picks_the_dominant_script() {
+        assert_eq!(language_for_text("வணக்கம், எப்படி இருக்கீங்க?"), "ta-IN");
+        assert_eq!(language_for_text("नमस्ते, आप कैसे हैं?"), "hi-IN");
+        assert_eq!(language_for_text("নমস্কার"), "bn-IN");
+        assert_eq!(language_for_text("ਸਤ ਸ੍ਰੀ ਅਕਾਲ"), "pa-IN");
+        assert_eq!(language_for_text("કેમ છો"), "gu-IN");
+        assert_eq!(language_for_text("ନମସ୍କାର"), "od-IN");
+        assert_eq!(language_for_text("నమస్కారం"), "te-IN");
+        assert_eq!(language_for_text("ನಮಸ್ಕಾರ"), "kn-IN");
+        assert_eq!(language_for_text("നമസ്കാരം"), "ml-IN");
+        // Latin / empty / punctuation-only → English (India).
+        assert_eq!(language_for_text("Hello, how are you?"), "en-IN");
+        assert_eq!(language_for_text(""), "en-IN");
+        assert_eq!(language_for_text("299!?"), "en-IN");
+        // Code-mixed: the DOMINANT script wins ("recharge" inside a Tamil reply).
+        assert_eq!(language_for_text("உங்க recharge plan ரெடி!"), "ta-IN");
+    }
 
     #[test]
     fn body_matches_sarvam_schema() {


### PR DESCRIPTION
Three upgrades to the Sarvam STT/TTS connectors, making the pinned model and
language actually reach the API and enabling multi-language sessions:

### 1. Factory arms honor `model` + `language` (`factory.rs`)

The `sarvam` arms previously built `SarvamStt::new(key)` / `SarvamTts::new(key, voice)`
and ignored everything else — a pinned model (`saaras:v2.5`, `bulbul:v3`) or language
silently ran on the client defaults (`saarika:v2.5`, `bulbul:v2`, auto-detect/`en-IN`).

- STT: applies `spec.model` and the `language` option (BCP-47, e.g. `hi-IN`;
  absent → auto-detect) via the existing builders.
- TTS: `spec.model` remains the **voice id** (the factory's TTS contract); the
  actual Bulbul model and `target_language_code` ride as the `model` / `language`
  options.

### 2. `saaras:*` models route to the translate endpoint (`stt/sarvam.rs`)

Sarvam serves the Saaras (transcribe + translate-to-English) models at
`/speech-to-text-translate`, not `/speech-to-text` — the plain endpoint rejects
them with a 400. A pure `endpoint_for(model)` seam picks the route by model
prefix; the translate route omits `language_code` (it auto-detects, output is
English). Both hosts stay fixed constants; the key stays in the
`api-subscription-key` header only.

Verified against the live API: `saaras:v2.5` returns the English translation at
the translate route; note `saaras:v2` is deprecated upstream (the API says to
use v2.5).

### 3. Per-utterance TTS language auto-detect (`tts/sarvam.rs`)

Sarvam TTS has no upstream auto-detect — `target_language_code` is mandatory.
New pure seam `language_for_text(text)` counts characters per Indic Unicode
block (Devanagari, Bengali, Gurmukhi, Gujarati, Odia, Tamil, Telugu, Kannada,
Malayalam) and returns the dominant script's BCP-47 code; text with no Indic
characters → `en-IN`. When the service language is set to `auto`, `run_tts`
resolves the target per utterance — one session can speak Tamil, Hindi, and
English replies back-to-back.